### PR TITLE
docs(v2): add minute-level autoresearch planning workspace and issue package

### DIFF
--- a/docs/feature/v2-minute-autoresearch/README.md
+++ b/docs/feature/v2-minute-autoresearch/README.md
@@ -1,0 +1,74 @@
+# V2 Minute Autoresearch — Canonical Planning Workspace
+
+## Overview
+
+This workspace is the canonical spec-driven planning surface for the clarified V2 architecture:
+
+- **Karpathy-style autoresearch loop** as the core
+- **minute-level strategy discovery/refinement** as the mission
+- **TradingAgents-inspired stock-discussion structure** only for strategy-facing research
+- **optional factor mining** under the same autoresearch loop
+- **backtester-driven keep/revert** as the final success rule
+
+The canonical source of truth for this workspace is:
+
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+
+## Canonical Decisions
+
+| Item | Decision | Why |
+| --- | --- | --- |
+| Docs root | `docs/` | This repo's live planning root is `docs/` |
+| Canonical workspace | `docs/feature/v2-minute-autoresearch/` | This is a feature-scoped V2 architecture effort, not a single bugfix |
+| Feature branch | `feature/v2-minute-autoresearch` | Dedicated planning branch based on `main-dev` |
+| Merge target | `main-dev` | User explicitly wants the docs package ready for `main-dev` integration |
+| Issue topology | one umbrella + four child issues | Smallest issue set that still matches the architecture workstreams |
+
+## GitLab Publication Blocker
+
+**Status:** blocked locally
+
+- `glab` is not installed on this machine
+- no GitLab CLI config was found under `~/.config`
+- issue cards below are therefore stored as **local publication-ready drafts**
+- publish them to GitLab later from a GitLab-capable environment and replace provisional references with real issue IDs/URLs
+
+## Workspace Map
+
+- `v2-minute-autoresearch-development-plan.md` — main phase plan and task tables
+- `v2-minute-autoresearch-backend.md` — architecture and runtime lane
+- `v2-minute-autoresearch-infra.md` — environment, data, merge-target, and publishing constraints
+- `v2-minute-autoresearch-test-plan.md` — verification matrix
+- `v2-minute-autoresearch-merge-test-plan.md` — merge-to-`main-dev` verification and publication follow-up
+- `issue-cards/` — umbrella + child issue-card drafts
+- `sprint1/` — issue A execution docs
+- `sprint2/` — issue B execution docs
+- `sprint3/` — issue C execution docs
+- `sprint4/` — issue D execution docs
+
+## Issue Draft Set
+
+- `issue-cards/umbrella-v2-minute-autoresearch.md`
+- `issue-cards/issue-a-autoresearch-core-idea-intake.md`
+- `issue-cards/issue-b-minute-runtime-validation.md`
+- `issue-cards/issue-c-strategy-stock-discussion.md`
+- `issue-cards/issue-d-optional-factor-mining.md`
+
+## Governing Specs
+
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+- `docs/research-karpathy-autoresearch.md`
+- `docs/research-tradingagents.md`
+- `docs/research-capabilities-v2.md`
+- `docs/data-pipeline-v2.md`
+- `docs/upgrade-plan-v2.md`
+- `program.md`
+
+## Acceptance Snapshot
+
+- [ ] GitLab issue drafts are published later with real IDs
+- [x] Canonical docs root is explicit
+- [x] One canonical feature workspace exists
+- [x] Child issue drafts map into `sprintN/` execution docs
+- [x] Planning package is written against `main-dev`
+

--- a/docs/feature/v2-minute-autoresearch/README.md
+++ b/docs/feature/v2-minute-autoresearch/README.md
@@ -24,14 +24,15 @@ The canonical source of truth for this workspace is:
 | Merge target | `main-dev` | User explicitly wants the docs package ready for `main-dev` integration |
 | Issue topology | one umbrella + four child issues | Smallest issue set that still matches the architecture workstreams |
 
-## GitLab Publication Blocker
+## GitHub Publication Status
 
-**Status:** blocked locally
+**Status:** published on 2026-04-09
 
-- `glab` is not installed on this machine
-- no GitLab CLI config was found under `~/.config`
-- issue cards below are therefore stored as **local publication-ready drafts**
-- publish them to GitLab later from a GitLab-capable environment and replace provisional references with real issue IDs/URLs
+- Umbrella: [#17](https://github.com/ricoyudog/Quant-Autoresearch/issues/17)
+- Issue A: [#18](https://github.com/ricoyudog/Quant-Autoresearch/issues/18)
+- Issue B: [#19](https://github.com/ricoyudog/Quant-Autoresearch/issues/19)
+- Issue C: [#20](https://github.com/ricoyudog/Quant-Autoresearch/issues/20)
+- Issue D: [#21](https://github.com/ricoyudog/Quant-Autoresearch/issues/21)
 
 ## Workspace Map
 
@@ -46,13 +47,13 @@ The canonical source of truth for this workspace is:
 - `sprint3/` — issue C execution docs
 - `sprint4/` — issue D execution docs
 
-## Issue Draft Set
+## Issue Set
 
-- `issue-cards/umbrella-v2-minute-autoresearch.md`
-- `issue-cards/issue-a-autoresearch-core-idea-intake.md`
-- `issue-cards/issue-b-minute-runtime-validation.md`
-- `issue-cards/issue-c-strategy-stock-discussion.md`
-- `issue-cards/issue-d-optional-factor-mining.md`
+- `issue-cards/umbrella-v2-minute-autoresearch.md` → [#17](https://github.com/ricoyudog/Quant-Autoresearch/issues/17)
+- `issue-cards/issue-a-autoresearch-core-idea-intake.md` → [#18](https://github.com/ricoyudog/Quant-Autoresearch/issues/18)
+- `issue-cards/issue-b-minute-runtime-validation.md` → [#19](https://github.com/ricoyudog/Quant-Autoresearch/issues/19)
+- `issue-cards/issue-c-strategy-stock-discussion.md` → [#20](https://github.com/ricoyudog/Quant-Autoresearch/issues/20)
+- `issue-cards/issue-d-optional-factor-mining.md` → [#21](https://github.com/ricoyudog/Quant-Autoresearch/issues/21)
 
 ## Governing Specs
 
@@ -66,9 +67,8 @@ The canonical source of truth for this workspace is:
 
 ## Acceptance Snapshot
 
-- [ ] GitLab issue drafts are published later with real IDs
+- [x] GitHub issue cards are published with real IDs
 - [x] Canonical docs root is explicit
 - [x] One canonical feature workspace exists
 - [x] Child issue drafts map into `sprintN/` execution docs
 - [x] Planning package is written against `main-dev`
-

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-a-autoresearch-core-idea-intake.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-a-autoresearch-core-idea-intake.md
@@ -2,8 +2,8 @@
 
 **Publication Status**
 
-- Local GitLab issue-card draft only
-- Intended label: `workflow::todo`
+- Published on GitHub as [#18](https://github.com/ricoyudog/Quant-Autoresearch/issues/18)
+- Applied label: `workflow::todo`
 
 **Feature Branch**
 
@@ -75,4 +75,3 @@
 
 - `docs/feature/v2-minute-autoresearch/sprint1/sprint1-backend.md`
 - `docs/feature/v2-minute-autoresearch/sprint1/sprint1-infra.md`
-

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-a-autoresearch-core-idea-intake.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-a-autoresearch-core-idea-intake.md
@@ -1,0 +1,78 @@
+# Issue Draft A — Autoresearch Core + Idea Intake
+
+**Publication Status**
+
+- Local GitLab issue-card draft only
+- Intended label: `workflow::todo`
+
+**Feature Branch**
+
+- `feature/v2-minute-autoresearch`
+
+**Goal**
+
+- Define the core autoresearch loop that ingests ideas from Obsidian and self-search, then turns them into candidate strategy refinements.
+
+**Scope**
+
+- idea ingestion from daily Obsidian capture
+- self-search for new ideas
+- candidate-generation / strategy-refinement semantics
+- results-first loop contract
+
+**Out of Scope**
+
+- minute runtime internals
+- stock discussion lane specifics
+- factor-mining implementation details
+
+**Docs Workspace**
+
+- `docs/feature/v2-minute-autoresearch/sprint1/sprint1-backend.md`
+- `docs/feature/v2-minute-autoresearch/sprint1/sprint1-infra.md`
+
+**Governing Specs**
+
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+- `docs/research-karpathy-autoresearch.md`
+- `program.md`
+
+**Phase Plan**
+
+| Phase | Goal | Deliverables | Status | Next Step |
+| --- | --- | --- | --- | --- |
+| Sprint 1 | define autoresearch core loop and idea intake | sprint1 backend/infra docs | pending | execute sprint1 docs later |
+
+**Task Table**
+
+| Task ID | Task | Owner | Dependency | Effort | Acceptance |
+| --- | --- | --- | --- | --- | --- |
+| A-01 | Define idea-ingestion sources and trigger points | BE | none | 0.2d | Obsidian + self-search roles are explicit |
+| A-02 | Define loop semantics for candidate generation and strategy update | BE | A-01 | 0.3d | loop contract is explicit |
+| A-03 | Define infra/runtime assumptions for the loop | Infra | A-01 | 0.1d | environment and data prerequisites are documented |
+
+**Detailed Todo**
+
+- [ ] finalize the exact idea-ingestion contract
+- [ ] finalize the autoresearch iteration contract
+- [ ] define keep/revert flow boundaries
+
+**Dependencies / Risks**
+
+- unclear coupling to current CLI surfaces
+- drift between `program.md` and future runtime orchestration
+
+**Verification Plan**
+
+- sprint1 docs exist and stay aligned to the canonical spec
+
+**Acceptance Criteria**
+
+- [ ] sprint1 backend/infra docs are execution-ready
+- [ ] idea ingestion and candidate generation are unambiguous
+
+**References**
+
+- `docs/feature/v2-minute-autoresearch/sprint1/sprint1-backend.md`
+- `docs/feature/v2-minute-autoresearch/sprint1/sprint1-infra.md`
+

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-b-minute-runtime-validation.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-b-minute-runtime-validation.md
@@ -1,0 +1,77 @@
+# Issue Draft B — Minute Runtime + Validation Alignment
+
+**Publication Status**
+
+- Local GitLab issue-card draft only
+- Intended label: `workflow::todo`
+
+**Feature Branch**
+
+- `feature/v2-minute-autoresearch`
+
+**Goal**
+
+- Converge the runtime architecture on the clarified minute-level mission while preserving the backtester as a hard invariant.
+
+**Scope**
+
+- minute-level mission enforcement
+- data/runtime alignment
+- backtester invariants
+- keep/revert authority
+
+**Out of Scope**
+
+- stock discussion UX or discussion structure
+- factor-mining mode details
+
+**Docs Workspace**
+
+- `docs/feature/v2-minute-autoresearch/sprint2/sprint2-backend.md`
+- `docs/feature/v2-minute-autoresearch/sprint2/sprint2-infra.md`
+
+**Governing Specs**
+
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+- `docs/data-pipeline-v2.md`
+- `docs/feature/v2-data-pipeline/v2-data-pipeline-development-plan.md`
+
+**Phase Plan**
+
+| Phase | Goal | Deliverables | Status | Next Step |
+| --- | --- | --- | --- | --- |
+| Sprint 2 | define minute runtime and validation alignment | sprint2 backend/infra docs | pending | execute sprint2 docs later |
+
+**Task Table**
+
+| Task ID | Task | Owner | Dependency | Effort | Acceptance |
+| --- | --- | --- | --- | --- | --- |
+| B-01 | Define minute-level runtime contract | BE | none | 0.2d | minute mission is explicit in runtime docs |
+| B-02 | Define backtester invariants and keep/revert gate | BE | B-01 | 0.2d | validation engine remains non-negotiable |
+| B-03 | Define environment/data prerequisites for minute pipeline | Infra | B-01 | 0.2d | prerequisites and merge assumptions are explicit |
+
+**Detailed Todo**
+
+- [ ] define minute-level mission enforcement
+- [ ] define how current runtime drifts from target runtime
+- [ ] define invariant-preserving implementation constraints
+
+**Dependencies / Risks**
+
+- current branch/runtime drift
+- minute-pipeline complexity could push design away from autoresearch simplicity
+
+**Verification Plan**
+
+- sprint2 docs exist and link back to canonical spec
+
+**Acceptance Criteria**
+
+- [ ] sprint2 docs are execution-ready
+- [ ] backtester invariants are treated as hard requirements
+
+**References**
+
+- `docs/feature/v2-minute-autoresearch/sprint2/sprint2-backend.md`
+- `docs/feature/v2-minute-autoresearch/sprint2/sprint2-infra.md`
+

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-b-minute-runtime-validation.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-b-minute-runtime-validation.md
@@ -2,8 +2,8 @@
 
 **Publication Status**
 
-- Local GitLab issue-card draft only
-- Intended label: `workflow::todo`
+- Published on GitHub as [#19](https://github.com/ricoyudog/Quant-Autoresearch/issues/19)
+- Applied label: `workflow::todo`
 
 **Feature Branch**
 
@@ -74,4 +74,3 @@
 
 - `docs/feature/v2-minute-autoresearch/sprint2/sprint2-backend.md`
 - `docs/feature/v2-minute-autoresearch/sprint2/sprint2-infra.md`
-

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md
@@ -2,8 +2,8 @@
 
 **Publication Status**
 
-- Local GitLab issue-card draft only
-- Intended label: `workflow::todo`
+- Published on GitHub as [#20](https://github.com/ricoyudog/Quant-Autoresearch/issues/20)
+- Applied label: `workflow::todo`
 
 **Feature Branch**
 
@@ -73,4 +73,3 @@
 
 - `docs/feature/v2-minute-autoresearch/sprint3/sprint3-backend.md`
 - `docs/feature/v2-minute-autoresearch/sprint3/sprint3-infra.md`
-

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md
@@ -1,0 +1,76 @@
+# Issue Draft C — Strategy-Facing Stock Discussion Lane
+
+**Publication Status**
+
+- Local GitLab issue-card draft only
+- Intended label: `workflow::todo`
+
+**Feature Branch**
+
+- `feature/v2-minute-autoresearch`
+
+**Goal**
+
+- Define how TradingAgents-inspired stock discussion should support strategy refinement without turning the system into a full TradingAgents clone.
+
+**Scope**
+
+- strategy-facing stock discussion inside autoresearch
+- boundary with lightweight deterministic `analyze`
+- structure of discussion outputs and their role in strategy refinement
+
+**Out of Scope**
+
+- generic stock-picking assistant behavior
+- full debate-orchestration runtime
+
+**Docs Workspace**
+
+- `docs/feature/v2-minute-autoresearch/sprint3/sprint3-backend.md`
+- `docs/feature/v2-minute-autoresearch/sprint3/sprint3-infra.md`
+
+**Governing Specs**
+
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+- `docs/research-tradingagents.md`
+- `docs/research-capabilities-v2.md`
+
+**Phase Plan**
+
+| Phase | Goal | Deliverables | Status | Next Step |
+| --- | --- | --- | --- | --- |
+| Sprint 3 | define stock-discussion lane and its boundary with analyze | sprint3 backend/infra docs | pending | execute sprint3 docs later |
+
+**Task Table**
+
+| Task ID | Task | Owner | Dependency | Effort | Acceptance |
+| --- | --- | --- | --- | --- | --- |
+| C-01 | Define strategy-facing stock-discussion structure | BE | none | 0.2d | structure supports strategy refinement |
+| C-02 | Define boundary with `analyze` snapshot helper | BE | C-01 | 0.1d | snapshot vs loop boundary is explicit |
+| C-03 | Define runtime/data assumptions for this lane | Infra | C-01 | 0.1d | prerequisites are documented |
+
+**Detailed Todo**
+
+- [ ] define where stock discussion enters the loop
+- [ ] define what stays in lightweight analyze
+- [ ] define how discussion feeds candidate strategies
+
+**Dependencies / Risks**
+
+- scope creep into generic investing analysis
+- over-borrowing from TradingAgents
+
+**Verification Plan**
+
+- sprint3 docs exist and preserve the boundary decisions from deep-interview
+
+**Acceptance Criteria**
+
+- [ ] sprint3 docs are execution-ready
+- [ ] stock discussion is clearly strategy-facing only
+
+**References**
+
+- `docs/feature/v2-minute-autoresearch/sprint3/sprint3-backend.md`
+- `docs/feature/v2-minute-autoresearch/sprint3/sprint3-infra.md`
+

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md
@@ -1,0 +1,76 @@
+# Issue Draft D — Optional Factor-Mining Lane
+
+**Publication Status**
+
+- Local GitLab issue-card draft only
+- Intended label: `workflow::todo`
+
+**Feature Branch**
+
+- `feature/v2-minute-autoresearch`
+
+**Goal**
+
+- Define factor mining as an optional autoresearch sub-mode that can be invoked when the main loop needs new alpha primitives/features.
+
+**Scope**
+
+- factor mining trigger criteria
+- relationship to autoresearch idea generation
+- result-based evaluation of factor usefulness
+
+**Out of Scope**
+
+- mandatory factor mining in every loop
+- standalone factor-mining product behavior
+
+**Docs Workspace**
+
+- `docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md`
+- `docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md`
+
+**Governing Specs**
+
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+- `docs/research-karpathy-autoresearch.md`
+- `https://github.com/QuantaAlpha/QuantaAlpha` (reference concept only; publication environment may add a stable archived note later)
+
+**Phase Plan**
+
+| Phase | Goal | Deliverables | Status | Next Step |
+| --- | --- | --- | --- | --- |
+| Sprint 4 | define optional factor-mining sub-mode | sprint4 backend/infra docs | pending | execute sprint4 docs later |
+
+**Task Table**
+
+| Task ID | Task | Owner | Dependency | Effort | Acceptance |
+| --- | --- | --- | --- | --- | --- |
+| D-01 | Define trigger criteria for factor mining | BE | none | 0.1d | factor mining is clearly optional |
+| D-02 | Define how factor mining feeds candidate generation | BE | D-01 | 0.2d | factor ideas stay under autoresearch |
+| D-03 | Define runtime/data assumptions and failure boundaries | Infra | D-01 | 0.1d | assumptions are explicit |
+
+**Detailed Todo**
+
+- [ ] define when factor mining should be invoked
+- [ ] define how factors become strategy candidates
+- [ ] define how factors are judged by results
+
+**Dependencies / Risks**
+
+- factor mining could bloat the main loop if not kept optional
+- factor quality could be misread as success without backtester validation
+
+**Verification Plan**
+
+- sprint4 docs exist and preserve the optional-submode rule
+
+**Acceptance Criteria**
+
+- [ ] sprint4 docs are execution-ready
+- [ ] factor mining is optional and results-first
+
+**References**
+
+- `docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md`
+- `docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md`
+

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md
@@ -2,8 +2,8 @@
 
 **Publication Status**
 
-- Local GitLab issue-card draft only
-- Intended label: `workflow::todo`
+- Published on GitHub as [#21](https://github.com/ricoyudog/Quant-Autoresearch/issues/21)
+- Applied label: `workflow::todo`
 
 **Feature Branch**
 
@@ -73,4 +73,3 @@
 
 - `docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md`
 - `docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md`
-

--- a/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
@@ -1,0 +1,101 @@
+# Umbrella Draft — V2 Minute Autoresearch Architecture
+
+**Publication Status**
+
+- Local GitLab issue-card draft only
+- Intended label: `workflow::todo`
+- GitLab publication blocker: `glab` unavailable locally
+
+**Feature Branch**
+
+- `feature/v2-minute-autoresearch`
+
+**Goal**
+
+- Turn the clarified deep-interview architecture into a canonical, spec-driven V2 planning package for minute-level autoresearch.
+
+**Scope**
+
+- autoresearch core
+- minute-level runtime/validation alignment
+- strategy-facing stock discussion lane
+- optional factor-mining lane
+- merge-ready planning docs for `main-dev`
+
+**Out of Scope**
+
+- full TradingAgents / LangGraph decision runtime
+- generic daily-investment research mode
+- immediate implementation from this draft
+
+**Docs Workspace**
+
+- `docs/feature/v2-minute-autoresearch/README.md`
+- `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md`
+- `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-backend.md`
+- `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-infra.md`
+- `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-test-plan.md`
+- `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md`
+
+**Governing Specs**
+
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+- `docs/research-karpathy-autoresearch.md`
+- `docs/research-tradingagents.md`
+- `docs/research-capabilities-v2.md`
+- `docs/data-pipeline-v2.md`
+- `program.md`
+
+**Phase Plan**
+
+| Phase | Goal | Deliverables | Status | Next Step |
+| --- | --- | --- | --- | --- |
+| Phase 0 — Spec Alignment | keep one canonical V2 architecture brief | deep-interview spec, branch choice, root choice | completed | preserve this workspace as source of truth |
+| Sprint 1 — Autoresearch Core | define core loop + idea intake lane | issue A draft + sprint1 docs | pending | publish issue A later |
+| Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue B draft + sprint2 docs | pending | publish issue B later |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue C draft + sprint3 docs | pending | publish issue C later |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue D draft + sprint4 docs | pending | publish issue D later |
+| Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, publication blocker note | in progress | replace draft refs with real issue IDs later |
+
+**Task Table**
+
+| Task ID | Task | Owner | Dependency | Effort | Acceptance |
+| --- | --- | --- | --- | --- | --- |
+| UMB-01 | Create canonical workspace | Planning | none | 0.1d | root exists under `docs/feature/` only |
+| UMB-02 | Draft child issues A-D | Planning | UMB-01 | 0.2d | four workstream issue drafts exist |
+| UMB-03 | Create sprint docs | Planning | UMB-02 | 0.3d | each child issue maps to sprint docs |
+| UMB-04 | Record GitLab blocker honestly | Infra | UMB-01 | 0.05d | no artifact falsely claims publication |
+
+**Detailed Todo**
+
+- [ ] publish umbrella and child drafts to GitLab later
+- [ ] add real issue IDs/URLs back into this umbrella card
+- [ ] use the sprint docs as the execution handoff surface
+
+**Dependencies / Risks**
+
+- GitLab tooling missing locally
+- current implementation may still drift from target V2
+- merge should target `main-dev`, not the stale `feature/v2-research` branch
+
+**Verification Plan**
+
+- see `v2-minute-autoresearch-test-plan.md`
+- see `v2-minute-autoresearch-merge-test-plan.md`
+
+**Acceptance Criteria**
+
+- [x] canonical workspace exists
+- [x] umbrella draft exists
+- [x] child issue drafts exist
+- [x] sprint docs exist
+- [ ] real GitLab publication completed later
+
+**References**
+
+- `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md`
+- `docs/feature/v2-minute-autoresearch/issue-cards/issue-a-autoresearch-core-idea-intake.md`
+- `docs/feature/v2-minute-autoresearch/issue-cards/issue-b-minute-runtime-validation.md`
+- `docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md`
+- `docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md`
+

--- a/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
@@ -2,9 +2,8 @@
 
 **Publication Status**
 
-- Local GitLab issue-card draft only
-- Intended label: `workflow::todo`
-- GitLab publication blocker: `glab` unavailable locally
+- Published on GitHub as [#17](https://github.com/ricoyudog/Quant-Autoresearch/issues/17)
+- Applied label: `workflow::todo`
 
 **Feature Branch**
 
@@ -51,11 +50,11 @@
 | Phase | Goal | Deliverables | Status | Next Step |
 | --- | --- | --- | --- | --- |
 | Phase 0 — Spec Alignment | keep one canonical V2 architecture brief | deep-interview spec, branch choice, root choice | completed | preserve this workspace as source of truth |
-| Sprint 1 — Autoresearch Core | define core loop + idea intake lane | issue A draft + sprint1 docs | pending | publish issue A later |
-| Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue B draft + sprint2 docs | pending | publish issue B later |
-| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue C draft + sprint3 docs | pending | publish issue C later |
-| Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue D draft + sprint4 docs | pending | publish issue D later |
-| Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, publication blocker note | in progress | replace draft refs with real issue IDs later |
+| Sprint 1 — Autoresearch Core | define core loop + idea intake lane | issue #18 + sprint1 docs | pending | execute sprint1 docs later |
+| Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue #19 + sprint2 docs | pending | execute sprint2 docs later |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs | pending | execute sprint3 docs later |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | pending | execute sprint4 docs later |
+| Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 
 **Task Table**
 
@@ -68,13 +67,13 @@
 
 **Detailed Todo**
 
-- [ ] publish umbrella and child drafts to GitLab later
-- [ ] add real issue IDs/URLs back into this umbrella card
+- [x] publish umbrella and child drafts to GitHub
+- [x] add real issue IDs/URLs back into this umbrella card
 - [ ] use the sprint docs as the execution handoff surface
 
 **Dependencies / Risks**
 
-- GitLab tooling missing locally
+- keep local draft and GitHub issue #17 synchronized
 - current implementation may still drift from target V2
 - merge should target `main-dev`, not the stale `feature/v2-research` branch
 
@@ -89,7 +88,7 @@
 - [x] umbrella draft exists
 - [x] child issue drafts exist
 - [x] sprint docs exist
-- [ ] real GitLab publication completed later
+- [x] GitHub publication completed
 
 **References**
 
@@ -98,4 +97,8 @@
 - `docs/feature/v2-minute-autoresearch/issue-cards/issue-b-minute-runtime-validation.md`
 - `docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md`
 - `docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md`
-
+- [#17](https://github.com/ricoyudog/Quant-Autoresearch/issues/17)
+- [#18](https://github.com/ricoyudog/Quant-Autoresearch/issues/18)
+- [#19](https://github.com/ricoyudog/Quant-Autoresearch/issues/19)
+- [#20](https://github.com/ricoyudog/Quant-Autoresearch/issues/20)
+- [#21](https://github.com/ricoyudog/Quant-Autoresearch/issues/21)

--- a/docs/feature/v2-minute-autoresearch/sprint1/sprint1-backend.md
+++ b/docs/feature/v2-minute-autoresearch/sprint1/sprint1-backend.md
@@ -1,0 +1,76 @@
+# Sprint 1 — Backend Plan
+
+> Feature: `v2-minute-autoresearch`
+> Role: `Backend`
+> Derived from: `Issue Draft A — Autoresearch Core + Idea Intake`
+> Last Updated: `2026-04-09`
+
+## 0) Governing Specs
+
+1. `.omx/specs/deep-interview-spec-vs-impl.md`
+2. `docs/research-karpathy-autoresearch.md`
+3. `program.md`
+
+## 1) Sprint Mission
+
+- Define the core autoresearch loop that uses Obsidian ideas and self-search to generate candidate strategy refinements for minute-level strategy research.
+
+## 2) Scope / Out of Scope
+
+**Scope**
+- loop semantics
+- idea-ingestion surfaces
+- candidate-generation contract
+
+**Out of Scope**
+- minute runtime internals
+- stock-discussion lane specifics
+- factor-mining details
+
+## 3) Step-by-Step Plan
+
+### Step 1 — Define idea intake
+- [ ] define how daily Obsidian notes enter the loop
+- [ ] define when the loop should search for new ideas itself
+- [ ] define the minimum structured context the loop consumes before proposing strategy changes
+
+### Step 2 — Define candidate generation
+- [ ] define how retrieved ideas become strategy hypotheses
+- [ ] define how those hypotheses modify or extend the current strategy
+- [ ] define how the loop avoids treating ideas as success before validation
+
+### Step 3 — Define keep / revert semantics
+- [ ] define the handoff from candidate generation to the backtester
+- [ ] define that backtester outcomes, not idea quality, determine keep / revert
+- [ ] define the outputs the loop must record after each iteration
+
+## 4) Test Plan
+
+- [ ] verify the loop contract still centers `program.md` / autoresearch
+- [ ] verify idea sources include both Obsidian and self-search
+- [ ] verify keep / revert remains backtester-driven
+
+## 5) Verification Commands
+
+```bash
+rg -n "autoresearch|Obsidian|idea|backtester|keep / revert|keep/revert" docs/feature/v2-minute-autoresearch/sprint1 -S
+```
+
+## 6) Implementation Update Space
+
+### Completed Work
+
+- leave blank until implemented
+
+### Command Results
+
+- leave blank until implemented
+
+### Blockers / Deviations
+
+- leave blank until implemented
+
+### Follow-ups
+
+- leave blank until implemented
+

--- a/docs/feature/v2-minute-autoresearch/sprint1/sprint1-infra.md
+++ b/docs/feature/v2-minute-autoresearch/sprint1/sprint1-infra.md
@@ -1,0 +1,74 @@
+# Sprint 1 — Infra Plan
+
+> Feature: `v2-minute-autoresearch`
+> Role: `Infra`
+> Derived from: `Issue Draft A — Autoresearch Core + Idea Intake`
+> Last Updated: `2026-04-09`
+
+## 0) Governing Specs
+
+1. `.omx/specs/deep-interview-spec-vs-impl.md`
+2. `program.md`
+3. `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-infra.md`
+
+## 1) Sprint Mission
+
+- Define the environment and source-of-truth assumptions that allow the autoresearch loop to read ideas from Obsidian and search for new ideas safely.
+
+## 2) Scope / Out of Scope
+
+**Scope**
+- Obsidian idea-source assumptions
+- search/runtime assumptions
+- persistent note expectations
+
+**Out of Scope**
+- minute runtime execution details
+- factor mining runtime specifics
+
+## 3) Step-by-Step Plan
+
+### Step 1 — Define idea-source assumptions
+- [ ] define where daily collected ideas live
+- [ ] define what minimum metadata or structure the loop can rely on
+- [ ] define fallback behavior when no suitable idea note exists
+
+### Step 2 — Define search/runtime assumptions
+- [ ] define when self-search is allowed to supplement local ideas
+- [ ] define what credentials or external services are optional vs required
+- [ ] define how missing search credentials degrade gracefully
+
+### Step 3 — Define recording expectations
+- [ ] define what outputs should be written back after a loop iteration
+- [ ] define how traceability to the input ideas is preserved
+
+## 4) Test Plan
+
+- [ ] verify Obsidian remains the primary upstream idea source
+- [ ] verify search remains supplemental, not authoritative
+- [ ] verify degraded modes are explicit
+
+## 5) Verification Commands
+
+```bash
+rg -n "Obsidian|search|credentials|fallback|idea" docs/feature/v2-minute-autoresearch/sprint1 -S
+```
+
+## 6) Implementation Update Space
+
+### Completed Work
+
+- leave blank until implemented
+
+### Command Results
+
+- leave blank until implemented
+
+### Blockers / Deviations
+
+- leave blank until implemented
+
+### Follow-ups
+
+- leave blank until implemented
+

--- a/docs/feature/v2-minute-autoresearch/sprint2/sprint2-backend.md
+++ b/docs/feature/v2-minute-autoresearch/sprint2/sprint2-backend.md
@@ -1,0 +1,73 @@
+# Sprint 2 — Backend Plan
+
+> Feature: `v2-minute-autoresearch`
+> Role: `Backend`
+> Derived from: `Issue Draft B — Minute Runtime + Validation Alignment`
+> Last Updated: `2026-04-09`
+
+## 0) Governing Specs
+
+1. `.omx/specs/deep-interview-spec-vs-impl.md`
+2. `docs/data-pipeline-v2.md`
+3. `docs/feature/v2-data-pipeline/v2-data-pipeline-development-plan.md`
+
+## 1) Sprint Mission
+
+- Define how the runtime converges on the minute-level mission while preserving the backtester as a hard invariant and final judge.
+
+## 2) Scope / Out of Scope
+
+**Scope**
+- minute-level mission contract
+- runtime/data alignment
+- backtester invariants
+
+**Out of Scope**
+- stock-discussion and factor-mining specifics
+
+## 3) Step-by-Step Plan
+
+### Step 1 — Define minute-level mission enforcement
+- [ ] define what it means for strategy-facing work to be truly minute-level
+- [ ] define what current daily-style behavior is no longer acceptable
+- [ ] define how minute-level purpose constrains future runtime surfaces
+
+### Step 2 — Preserve validation invariants
+- [ ] define the invariants that may not regress: sandbox, walk-forward, forced lag, metrics
+- [ ] define what parts of the backtester are architecture-level constraints rather than implementation details
+- [ ] define how keep / revert depends on validation outputs
+
+### Step 3 — Define runtime convergence targets
+- [ ] define the current-state vs target-state gap for runtime/data flow
+- [ ] define the sequencing for closing that gap without losing validation integrity
+
+## 4) Test Plan
+
+- [ ] verify the sprint keeps the backtester as final authority
+- [ ] verify minute-level purpose is explicit
+- [ ] verify no architecture drift back into generic daily research
+
+## 5) Verification Commands
+
+```bash
+rg -n "minute|intraday|backtester|walk-forward|sandbox|forced lag" docs/feature/v2-minute-autoresearch/sprint2 -S
+```
+
+## 6) Implementation Update Space
+
+### Completed Work
+
+- leave blank until implemented
+
+### Command Results
+
+- leave blank until implemented
+
+### Blockers / Deviations
+
+- leave blank until implemented
+
+### Follow-ups
+
+- leave blank until implemented
+

--- a/docs/feature/v2-minute-autoresearch/sprint2/sprint2-infra.md
+++ b/docs/feature/v2-minute-autoresearch/sprint2/sprint2-infra.md
@@ -1,0 +1,73 @@
+# Sprint 2 — Infra Plan
+
+> Feature: `v2-minute-autoresearch`
+> Role: `Infra`
+> Derived from: `Issue Draft B — Minute Runtime + Validation Alignment`
+> Last Updated: `2026-04-09`
+
+## 0) Governing Specs
+
+1. `.omx/specs/deep-interview-spec-vs-impl.md`
+2. `docs/data-pipeline-v2.md`
+3. `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-infra.md`
+
+## 1) Sprint Mission
+
+- Define the infrastructure assumptions needed for a real minute-level runtime and ensure they stay aligned with the merge target.
+
+## 2) Scope / Out of Scope
+
+**Scope**
+- minute-data prerequisites
+- environment/data assumptions
+- merge-target documentation
+
+**Out of Scope**
+- strategy-discussion content
+- factor-mining behavior
+
+## 3) Step-by-Step Plan
+
+### Step 1 — Define minute-data prerequisites
+- [ ] define required data sources and local datasets
+- [ ] define what is optional vs mandatory
+- [ ] define the failure mode when minute-level prerequisites are absent
+
+### Step 2 — Define merge-target and baseline assumptions
+- [ ] define `main-dev` as the merge target baseline
+- [ ] define how future execution should avoid stale branch drift
+
+### Step 3 — Define infrastructure risks
+- [ ] document performance, storage, and environment risks for minute-level operation
+- [ ] document any blockers that could delay runtime convergence
+
+## 4) Test Plan
+
+- [ ] verify minute-level prerequisites are explicit
+- [ ] verify branch/merge assumptions are explicit
+- [ ] verify infra risks are documented before execution
+
+## 5) Verification Commands
+
+```bash
+rg -n "minute|dataset|main-dev|merge target|risk|prerequisite" docs/feature/v2-minute-autoresearch/sprint2 -S
+```
+
+## 6) Implementation Update Space
+
+### Completed Work
+
+- leave blank until implemented
+
+### Command Results
+
+- leave blank until implemented
+
+### Blockers / Deviations
+
+- leave blank until implemented
+
+### Follow-ups
+
+- leave blank until implemented
+

--- a/docs/feature/v2-minute-autoresearch/sprint3/sprint3-backend.md
+++ b/docs/feature/v2-minute-autoresearch/sprint3/sprint3-backend.md
@@ -1,0 +1,74 @@
+# Sprint 3 — Backend Plan
+
+> Feature: `v2-minute-autoresearch`
+> Role: `Backend`
+> Derived from: `Issue Draft C — Strategy-Facing Stock Discussion Lane`
+> Last Updated: `2026-04-09`
+
+## 0) Governing Specs
+
+1. `.omx/specs/deep-interview-spec-vs-impl.md`
+2. `docs/research-tradingagents.md`
+3. `docs/research-capabilities-v2.md`
+
+## 1) Sprint Mission
+
+- Define a TradingAgents-inspired stock-discussion structure that serves strategy refinement without becoming a separate decision engine.
+
+## 2) Scope / Out of Scope
+
+**Scope**
+- strategy-facing stock discussion structure
+- integration into autoresearch
+- boundary with lightweight `analyze`
+
+**Out of Scope**
+- generic portfolio advice
+- full debate-runtime orchestration
+
+## 3) Step-by-Step Plan
+
+### Step 1 — Define discussion entry points
+- [ ] define when stock discussion is triggered inside autoresearch
+- [ ] define what strategy questions it should answer
+- [ ] define what it must not absorb
+
+### Step 2 — Define output shape
+- [ ] define the structured discussion output
+- [ ] define how it feeds strategy hypotheses instead of final buy/sell decisions
+- [ ] define how negative / contrarian reasoning is preserved
+
+### Step 3 — Define `analyze` boundary
+- [ ] define what remains a deterministic snapshot
+- [ ] define what escalates into full strategy-facing discussion
+
+## 4) Test Plan
+
+- [ ] verify TradingAgents borrowing stays structural only
+- [ ] verify the lane remains strategy-facing only
+- [ ] verify `analyze` boundary remains explicit
+
+## 5) Verification Commands
+
+```bash
+rg -n "TradingAgents|stock discussion|analyze|strategy-facing|contrarian" docs/feature/v2-minute-autoresearch/sprint3 -S
+```
+
+## 6) Implementation Update Space
+
+### Completed Work
+
+- leave blank until implemented
+
+### Command Results
+
+- leave blank until implemented
+
+### Blockers / Deviations
+
+- leave blank until implemented
+
+### Follow-ups
+
+- leave blank until implemented
+

--- a/docs/feature/v2-minute-autoresearch/sprint3/sprint3-infra.md
+++ b/docs/feature/v2-minute-autoresearch/sprint3/sprint3-infra.md
@@ -1,0 +1,71 @@
+# Sprint 3 — Infra Plan
+
+> Feature: `v2-minute-autoresearch`
+> Role: `Infra`
+> Derived from: `Issue Draft C — Strategy-Facing Stock Discussion Lane`
+> Last Updated: `2026-04-09`
+
+## 0) Governing Specs
+
+1. `.omx/specs/deep-interview-spec-vs-impl.md`
+2. `docs/research-tradingagents.md`
+3. `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-infra.md`
+
+## 1) Sprint Mission
+
+- Define the supporting data/runtime assumptions for the stock-discussion lane without letting it drift into a generic investing-analysis tool.
+
+## 2) Scope / Out of Scope
+
+**Scope**
+- supporting data assumptions
+- runtime constraints
+- traceability of discussion outputs
+
+**Out of Scope**
+- factor mining
+- minute runtime core data pipeline
+
+## 3) Step-by-Step Plan
+
+### Step 1 — Define data assumptions
+- [ ] define what market context the lane may consume
+- [ ] define what remains deterministic vs research-driven
+
+### Step 2 — Define runtime constraints
+- [ ] define what prevents this lane from becoming a separate decision product
+- [ ] define how results stay subordinate to the backtester
+
+### Step 3 — Define traceability expectations
+- [ ] define how discussion outputs are recorded
+- [ ] define how they link back to strategy candidate generation
+
+## 4) Test Plan
+
+- [ ] verify discussion outputs do not masquerade as final decisions
+- [ ] verify traceability back to strategy refinement exists
+
+## 5) Verification Commands
+
+```bash
+rg -n "traceability|discussion|decision|backtester|deterministic" docs/feature/v2-minute-autoresearch/sprint3 -S
+```
+
+## 6) Implementation Update Space
+
+### Completed Work
+
+- leave blank until implemented
+
+### Command Results
+
+- leave blank until implemented
+
+### Blockers / Deviations
+
+- leave blank until implemented
+
+### Follow-ups
+
+- leave blank until implemented
+

--- a/docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md
+++ b/docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md
@@ -1,0 +1,72 @@
+# Sprint 4 — Backend Plan
+
+> Feature: `v2-minute-autoresearch`
+> Role: `Backend`
+> Derived from: `Issue Draft D — Optional Factor-Mining Lane`
+> Last Updated: `2026-04-09`
+
+## 0) Governing Specs
+
+1. `.omx/specs/deep-interview-spec-vs-impl.md`
+2. `docs/research-karpathy-autoresearch.md`
+3. `docs/research-tradingagents.md`
+
+## 1) Sprint Mission
+
+- Define factor mining as an optional sub-mode of autoresearch that discovers new candidate features/factors only when the main loop needs them.
+
+## 2) Scope / Out of Scope
+
+**Scope**
+- factor-mining triggers
+- factor candidate generation
+- result-based factor evaluation
+
+**Out of Scope**
+- mandatory factor mining every cycle
+- standalone factor-mining product flow
+
+## 3) Step-by-Step Plan
+
+### Step 1 — Define trigger criteria
+- [ ] define when the main loop should invoke factor mining
+- [ ] define what symptoms or needs justify it
+
+### Step 2 — Define candidate integration
+- [ ] define how mined factors become strategy candidates
+- [ ] define how they remain subordinate to the main autoresearch idea loop
+
+### Step 3 — Define outcome judgment
+- [ ] define that factor quality is only meaningful through improved validated results
+- [ ] define how poor-result factors are discarded
+
+## 4) Test Plan
+
+- [ ] verify factor mining is optional
+- [ ] verify factor ideas stay under autoresearch
+- [ ] verify backtester remains the outcome judge
+
+## 5) Verification Commands
+
+```bash
+rg -n "factor mining|optional|candidate|results|backtester" docs/feature/v2-minute-autoresearch/sprint4 -S
+```
+
+## 6) Implementation Update Space
+
+### Completed Work
+
+- leave blank until implemented
+
+### Command Results
+
+- leave blank until implemented
+
+### Blockers / Deviations
+
+- leave blank until implemented
+
+### Follow-ups
+
+- leave blank until implemented
+

--- a/docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md
+++ b/docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md
@@ -1,0 +1,70 @@
+# Sprint 4 — Infra Plan
+
+> Feature: `v2-minute-autoresearch`
+> Role: `Infra`
+> Derived from: `Issue Draft D — Optional Factor-Mining Lane`
+> Last Updated: `2026-04-09`
+
+## 0) Governing Specs
+
+1. `.omx/specs/deep-interview-spec-vs-impl.md`
+2. `docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-infra.md`
+
+## 1) Sprint Mission
+
+- Define the supporting constraints for optional factor mining so it remains lightweight, traceable, and subordinate to the main autoresearch loop.
+
+## 2) Scope / Out of Scope
+
+**Scope**
+- trigger environment assumptions
+- storage / traceability expectations
+- failure boundaries
+
+**Out of Scope**
+- generic factor library productization
+
+## 3) Step-by-Step Plan
+
+### Step 1 — Define environment assumptions
+- [ ] define what data or compute assumptions factor mining may rely on
+- [ ] define how it degrades when those assumptions are missing
+
+### Step 2 — Define traceability/storage
+- [ ] define how factor proposals are recorded
+- [ ] define how their linkage back to final results is preserved
+
+### Step 3 — Define failure boundaries
+- [ ] define how factor-mining failure should not stall the main loop unnecessarily
+- [ ] define when the lane should be skipped entirely
+
+## 4) Test Plan
+
+- [ ] verify factor mining remains optional
+- [ ] verify traceability back to results is explicit
+- [ ] verify failure does not silently redefine the system mission
+
+## 5) Verification Commands
+
+```bash
+rg -n "factor|traceability|optional|failure|skip" docs/feature/v2-minute-autoresearch/sprint4 -S
+```
+
+## 6) Implementation Update Space
+
+### Completed Work
+
+- leave blank until implemented
+
+### Command Results
+
+- leave blank until implemented
+
+### Blockers / Deviations
+
+- leave blank until implemented
+
+### Follow-ups
+
+- leave blank until implemented
+

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-backend.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-backend.md
@@ -1,0 +1,48 @@
+# V2 Minute Autoresearch — Backend Plan
+
+## Goal
+
+Define the runtime/architecture work needed so implementation later converges on:
+
+- a minute-level autoresearch core
+- strategy-facing stock discussion under autoresearch
+- optional factor mining under the same loop
+- backtester-driven keep/revert
+
+## Scope
+
+- autoresearch loop semantics
+- idea intake from Obsidian + self-search
+- integration boundaries for stock discussion
+- optional factor-mining sub-mode
+- validation-engine invariants
+
+## Out Of Scope
+
+- UI work
+- GitLab publication mechanics
+- full execution details beyond the sprint docs
+
+## Workstream Mapping
+
+- Sprint 1: autoresearch core + idea intake
+- Sprint 2: minute runtime + validation alignment
+- Sprint 3: strategy-facing stock discussion
+- Sprint 4: optional factor mining
+
+## Backend Deliverables
+
+- canonical loop contract
+- minute-level mission enforcement contract
+- stock-discussion integration contract
+- factor-mining trigger contract
+- keep/revert outcome contract
+
+## References
+
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+- `docs/research-karpathy-autoresearch.md`
+- `docs/research-tradingagents.md`
+- `docs/data-pipeline-v2.md`
+- `program.md`
+

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
@@ -4,7 +4,7 @@
 > Merge target: `main-dev`
 > Canonical root: `docs/feature/v2-minute-autoresearch/`
 > Source brief: `.omx/specs/deep-interview-spec-vs-impl.md`
-> Planning status: Phase 0 complete; local issue/doc package created; GitLab publication blocked locally
+> Planning status: Phase 0 complete; GitHub issue package published; merge handoff targets `main-dev`
 
 ## 1. Context
 
@@ -30,22 +30,21 @@ This workspace turns that clarified architecture into a merge-ready planning pac
 Repo note:
 
 - local `main-dev` existed but was fast-forwarded to match `fork/main-dev`
-- issue publication is currently blocked because `glab` is unavailable locally
+- GitHub issues were published on 2026-04-09 as `#17` through `#21`
 
 ## 3. Scope
 
 - define the canonical V2 architecture package
 - split the work into the required issue-sized workstreams
 - create sprint docs for each child issue
-- document the GitLab publication blocker without losing planning structure
+- publish the issue package and keep docs aligned to the live issue set
 - keep the package ready to merge into `main-dev`
 
 ## 4. Out Of Scope
 
 - implementing the V2 architecture itself
 - reopening unrelated prior feature closeout work
-- posting GitLab cards from this machine
-- guessing GitLab board IDs or workflow state without a GitLab-capable environment
+- reopening issue publication structure that already exists on GitHub
 
 ## 5. Workstream / Issue Topology
 
@@ -62,11 +61,11 @@ Repo note:
 | Phase | Goal | Deliverables | Status | Next Step |
 | --- | --- | --- | --- | --- |
 | Phase 0 — Architecture Alignment | lock canonical V2 shape and workspace root | deep-interview spec, branch decision, workspace root choice | completed | keep this workspace as the single planning root |
-| Sprint 1 — Autoresearch Core | define loop semantics and idea-ingestion lane | issue A draft, sprint1 backend/infra docs | pending | publish issue A when GitLab is available |
-| Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue B draft, sprint2 backend/infra docs | pending | publish issue B when GitLab is available |
-| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue C draft, sprint3 backend/infra docs | pending | publish issue C when GitLab is available |
-| Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue D draft, sprint4 backend/infra docs | pending | publish issue D when GitLab is available |
-| Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, issue publication blocker note | in progress | replace draft issue references with real GitLab IDs later |
+| Sprint 1 — Autoresearch Core | define loop semantics and idea-ingestion lane | issue #18, sprint1 backend/infra docs | pending | execute sprint1 docs later |
+| Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue #19, sprint2 backend/infra docs | pending | execute sprint2 docs later |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs | pending | execute sprint3 docs later |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | pending | execute sprint4 docs later |
+| Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 
 ## 7. Task Table
 
@@ -76,7 +75,7 @@ Repo note:
 | PLAN-02 | Draft umbrella issue card | Planning | PLAN-01 | 0.1d | issue draft has required sections and references |
 | PLAN-03 | Draft child issue cards A-D | Planning | PLAN-02 | 0.2d | each workstream has a structured issue draft |
 | PLAN-04 | Create sprint docs for issues A-D | Planning | PLAN-03 | 0.3d | each child issue has at least one sprint doc |
-| PLAN-05 | Record GitLab publication blocker and merge path | Infra | PLAN-02 | 0.1d | blocker and next publication step are explicit |
+| PLAN-05 | Publish the issue package to GitHub and record live issue links | Infra | PLAN-02 | 0.1d | live issue links replace provisional draft-only status |
 | PLAN-06 | Verify the full docs package against `main-dev` | QA | PLAN-04, PLAN-05 | 0.1d | references, roots, and branch targets are coherent |
 
 ## 8. Detailed Todo
@@ -87,15 +86,15 @@ Repo note:
 - [x] write backend / infra / test / merge-test planning docs
 - [x] write local issue-card drafts for umbrella + four child issues
 - [x] create `sprint1/` through `sprint4/` execution docs
-- [ ] publish the issue-card drafts to GitLab from a GitLab-capable environment
-- [ ] replace provisional issue references with real issue URLs/IDs
+- [x] publish the issue-card drafts to GitHub
+- [x] replace provisional issue references with real issue URLs/IDs
 - [ ] merge the planning package into `main-dev`
 
 ## 9. Dependencies / Risks
 
 | Risk | Mitigation |
 | --- | --- |
-| GitLab publication cannot happen locally | keep publication-ready drafts in `issue-cards/` and document blocker explicitly |
+| GitHub issue set could drift from local docs if manually edited later | keep local issue-card drafts synced with the published cards |
 | Future implementation might drift from the clarified spec | treat `.omx/specs/deep-interview-spec-vs-impl.md` as the governing brief |
 | Workstreams could be too coarse or too fine | use umbrella + four child issues only |
 | Merge-to-`main-dev` could accidentally mix unrelated work | keep this planning package on a dedicated feature branch |
@@ -106,7 +105,7 @@ Repo note:
 - verify one canonical docs root
 - verify every child issue has sprint docs
 - verify issue-card drafts have required sections
-- verify blocker note exists for GitLab publication
+- verify published issue links and local draft sync
 
 ## 11. Acceptance Criteria
 
@@ -115,9 +114,9 @@ Repo note:
 - [x] umbrella issue draft exists
 - [x] four child issue drafts exist
 - [x] `sprint1/` … `sprint4/` docs exist
-- [x] GitLab blocker is documented
+- [x] GitHub issue links are published
 - [x] merge target is documented as `main-dev`
-- [ ] real GitLab issue URLs replace draft references
+- [x] real GitHub issue URLs replace draft references
 
 ## 12. References
 
@@ -131,5 +130,9 @@ Repo note:
 - [issue-cards/issue-b-minute-runtime-validation.md](./issue-cards/issue-b-minute-runtime-validation.md)
 - [issue-cards/issue-c-strategy-stock-discussion.md](./issue-cards/issue-c-strategy-stock-discussion.md)
 - [issue-cards/issue-d-optional-factor-mining.md](./issue-cards/issue-d-optional-factor-mining.md)
+- [#17](https://github.com/ricoyudog/Quant-Autoresearch/issues/17)
+- [#18](https://github.com/ricoyudog/Quant-Autoresearch/issues/18)
+- [#19](https://github.com/ricoyudog/Quant-Autoresearch/issues/19)
+- [#20](https://github.com/ricoyudog/Quant-Autoresearch/issues/20)
+- [#21](https://github.com/ricoyudog/Quant-Autoresearch/issues/21)
 - `.omx/specs/deep-interview-spec-vs-impl.md`
-

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
@@ -1,0 +1,135 @@
+# V2 Minute Autoresearch — Development Plan
+
+> Feature branch: `feature/v2-minute-autoresearch`
+> Merge target: `main-dev`
+> Canonical root: `docs/feature/v2-minute-autoresearch/`
+> Source brief: `.omx/specs/deep-interview-spec-vs-impl.md`
+> Planning status: Phase 0 complete; local issue/doc package created; GitLab publication blocked locally
+
+## 1. Context
+
+The V2 architecture is now clarified:
+
+- The system is **not** a full TradingAgents-style decision engine
+- The system **is** a minute-level autoresearch platform
+- Obsidian ideas + new search produce candidate ideas
+- Strategy-facing stock discussion belongs inside autoresearch
+- Snapshot analysis may remain lightweight in `analyze`
+- Optional factor mining exists under the same autoresearch loop
+- The backtester remains the final keep/revert authority
+
+This workspace turns that clarified architecture into a merge-ready planning package under one canonical docs root.
+
+## 2. Root And Branch Decision
+
+- Active docs root: `docs/`
+- Canonical workspace: `docs/feature/v2-minute-autoresearch/`
+- Canonical branch: `feature/v2-minute-autoresearch`
+- Merge target: `main-dev`
+
+Repo note:
+
+- local `main-dev` existed but was fast-forwarded to match `fork/main-dev`
+- issue publication is currently blocked because `glab` is unavailable locally
+
+## 3. Scope
+
+- define the canonical V2 architecture package
+- split the work into the required issue-sized workstreams
+- create sprint docs for each child issue
+- document the GitLab publication blocker without losing planning structure
+- keep the package ready to merge into `main-dev`
+
+## 4. Out Of Scope
+
+- implementing the V2 architecture itself
+- reopening unrelated prior feature closeout work
+- posting GitLab cards from this machine
+- guessing GitLab board IDs or workflow state without a GitLab-capable environment
+
+## 5. Workstream / Issue Topology
+
+| Draft ID | Workstream | Purpose |
+| --- | --- | --- |
+| UMB | Umbrella — V2 minute autoresearch architecture | index card and planning umbrella |
+| A | Autoresearch core + idea intake | Obsidian intake, self-search, loop semantics |
+| B | Minute runtime + validation alignment | minute mission, data/runtime alignment, backtester invariants |
+| C | Strategy-facing stock discussion lane | TradingAgents-inspired structure under autoresearch |
+| D | Optional factor-mining lane | on-demand factor discovery under autoresearch |
+
+## 6. Phase Plan
+
+| Phase | Goal | Deliverables | Status | Next Step |
+| --- | --- | --- | --- | --- |
+| Phase 0 — Architecture Alignment | lock canonical V2 shape and workspace root | deep-interview spec, branch decision, workspace root choice | completed | keep this workspace as the single planning root |
+| Sprint 1 — Autoresearch Core | define loop semantics and idea-ingestion lane | issue A draft, sprint1 backend/infra docs | pending | publish issue A when GitLab is available |
+| Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue B draft, sprint2 backend/infra docs | pending | publish issue B when GitLab is available |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue C draft, sprint3 backend/infra docs | pending | publish issue C when GitLab is available |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue D draft, sprint4 backend/infra docs | pending | publish issue D when GitLab is available |
+| Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, issue publication blocker note | in progress | replace draft issue references with real GitLab IDs later |
+
+## 7. Task Table
+
+| Task ID | Task | Lane | Dependency | Effort | Acceptance |
+| --- | --- | --- | --- | --- | --- |
+| PLAN-01 | Create canonical feature workspace | Planning | none | 0.1d | workspace exists under one root only |
+| PLAN-02 | Draft umbrella issue card | Planning | PLAN-01 | 0.1d | issue draft has required sections and references |
+| PLAN-03 | Draft child issue cards A-D | Planning | PLAN-02 | 0.2d | each workstream has a structured issue draft |
+| PLAN-04 | Create sprint docs for issues A-D | Planning | PLAN-03 | 0.3d | each child issue has at least one sprint doc |
+| PLAN-05 | Record GitLab publication blocker and merge path | Infra | PLAN-02 | 0.1d | blocker and next publication step are explicit |
+| PLAN-06 | Verify the full docs package against `main-dev` | QA | PLAN-04, PLAN-05 | 0.1d | references, roots, and branch targets are coherent |
+
+## 8. Detailed Todo
+
+- [x] create branch `feature/v2-minute-autoresearch`
+- [x] create canonical docs workspace under `docs/feature/v2-minute-autoresearch/`
+- [x] write README and main development plan
+- [x] write backend / infra / test / merge-test planning docs
+- [x] write local issue-card drafts for umbrella + four child issues
+- [x] create `sprint1/` through `sprint4/` execution docs
+- [ ] publish the issue-card drafts to GitLab from a GitLab-capable environment
+- [ ] replace provisional issue references with real issue URLs/IDs
+- [ ] merge the planning package into `main-dev`
+
+## 9. Dependencies / Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| GitLab publication cannot happen locally | keep publication-ready drafts in `issue-cards/` and document blocker explicitly |
+| Future implementation might drift from the clarified spec | treat `.omx/specs/deep-interview-spec-vs-impl.md` as the governing brief |
+| Workstreams could be too coarse or too fine | use umbrella + four child issues only |
+| Merge-to-`main-dev` could accidentally mix unrelated work | keep this planning package on a dedicated feature branch |
+
+## 10. Verification Plan
+
+- verify branch name and target base
+- verify one canonical docs root
+- verify every child issue has sprint docs
+- verify issue-card drafts have required sections
+- verify blocker note exists for GitLab publication
+
+## 11. Acceptance Criteria
+
+- [x] `docs/feature/v2-minute-autoresearch/` exists
+- [x] `feature/v2-minute-autoresearch` exists and is based on `main-dev`
+- [x] umbrella issue draft exists
+- [x] four child issue drafts exist
+- [x] `sprint1/` … `sprint4/` docs exist
+- [x] GitLab blocker is documented
+- [x] merge target is documented as `main-dev`
+- [ ] real GitLab issue URLs replace draft references
+
+## 12. References
+
+- [README.md](./README.md)
+- [v2-minute-autoresearch-backend.md](./v2-minute-autoresearch-backend.md)
+- [v2-minute-autoresearch-infra.md](./v2-minute-autoresearch-infra.md)
+- [v2-minute-autoresearch-test-plan.md](./v2-minute-autoresearch-test-plan.md)
+- [v2-minute-autoresearch-merge-test-plan.md](./v2-minute-autoresearch-merge-test-plan.md)
+- [issue-cards/umbrella-v2-minute-autoresearch.md](./issue-cards/umbrella-v2-minute-autoresearch.md)
+- [issue-cards/issue-a-autoresearch-core-idea-intake.md](./issue-cards/issue-a-autoresearch-core-idea-intake.md)
+- [issue-cards/issue-b-minute-runtime-validation.md](./issue-cards/issue-b-minute-runtime-validation.md)
+- [issue-cards/issue-c-strategy-stock-discussion.md](./issue-cards/issue-c-strategy-stock-discussion.md)
+- [issue-cards/issue-d-optional-factor-mining.md](./issue-cards/issue-d-optional-factor-mining.md)
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-infra.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-infra.md
@@ -8,7 +8,7 @@ Capture the non-code planning constraints required for this feature package to r
 
 - branch and merge target
 - docs root and workspace shape
-- GitLab publication blocker
+- GitHub issue publication status
 - Obsidian / minute-data / environment expectations that the future implementation will depend on
 
 ## Key Constraints
@@ -16,9 +16,12 @@ Capture the non-code planning constraints required for this feature package to r
 - feature branch: `feature/v2-minute-autoresearch`
 - merge target: `main-dev`
 - canonical docs root: `docs/feature/v2-minute-autoresearch/`
-- GitLab publication currently blocked because:
-  - `glab` not installed
-  - no GitLab CLI config found
+- GitHub issues published:
+  - umbrella `#17`
+  - issue A `#18`
+  - issue B `#19`
+  - issue C `#20`
+  - issue D `#21`
 
 ## Runtime Expectations To Preserve
 
@@ -28,15 +31,10 @@ Capture the non-code planning constraints required for this feature package to r
 
 ## Publication Follow-up
 
-Once a GitLab-capable environment exists:
-
-- publish umbrella draft
-- publish child issue drafts
-- confirm `workflow::todo` board/list
-- replace local draft references with live issue links
+- keep the local issue-card drafts synchronized with the live GitHub issues
+- keep the `workflow::todo` label contract consistent for future issue creation
 
 ## References
 
 - `.omx/context/v2-minute-autoresearch-orchestration-20260409T074500Z.md`
 - `.omx/specs/deep-interview-spec-vs-impl.md`
-

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-infra.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-infra.md
@@ -1,0 +1,42 @@
+# V2 Minute Autoresearch — Infra Plan
+
+## Goal
+
+Capture the non-code planning constraints required for this feature package to remain mergeable and publishable later.
+
+## Scope
+
+- branch and merge target
+- docs root and workspace shape
+- GitLab publication blocker
+- Obsidian / minute-data / environment expectations that the future implementation will depend on
+
+## Key Constraints
+
+- feature branch: `feature/v2-minute-autoresearch`
+- merge target: `main-dev`
+- canonical docs root: `docs/feature/v2-minute-autoresearch/`
+- GitLab publication currently blocked because:
+  - `glab` not installed
+  - no GitLab CLI config found
+
+## Runtime Expectations To Preserve
+
+- Obsidian remains the upstream idea store
+- minute-level strategy mission remains primary
+- backtester invariants remain hard constraints
+
+## Publication Follow-up
+
+Once a GitLab-capable environment exists:
+
+- publish umbrella draft
+- publish child issue drafts
+- confirm `workflow::todo` board/list
+- replace local draft references with live issue links
+
+## References
+
+- `.omx/context/v2-minute-autoresearch-orchestration-20260409T074500Z.md`
+- `.omx/specs/deep-interview-spec-vs-impl.md`
+

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md
@@ -1,0 +1,34 @@
+# V2 Minute Autoresearch — Merge Test Plan
+
+## Goal
+
+Ensure the planning package can be reviewed and merged into `main-dev` without hidden root drift or missing execution handoff.
+
+## Merge Checks
+
+- [ ] branch is `feature/v2-minute-autoresearch`
+- [ ] base/target is documented as `main-dev`
+- [ ] only one canonical feature root exists
+- [ ] issue drafts point to sprint docs
+- [ ] sprint docs point back to governing specs and issue drafts
+- [ ] GitLab publication blocker is explicit and honest
+
+## Commands
+
+```bash
+git branch --show-current
+git diff --name-only main-dev..HEAD
+find docs/feature/v2-minute-autoresearch -maxdepth 3 -type f | sort
+```
+
+## Update Space
+
+### Merge Readiness Notes
+
+- leave blank until closeout
+
+### Publication Follow-up
+
+- publish local issue drafts to GitLab
+- replace draft references with real IDs
+

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md
@@ -11,7 +11,7 @@ Ensure the planning package can be reviewed and merged into `main-dev` without h
 - [ ] only one canonical feature root exists
 - [ ] issue drafts point to sprint docs
 - [ ] sprint docs point back to governing specs and issue drafts
-- [ ] GitLab publication blocker is explicit and honest
+- [ ] GitHub issue links are explicit and honest
 
 ## Commands
 
@@ -29,6 +29,5 @@ find docs/feature/v2-minute-autoresearch -maxdepth 3 -type f | sort
 
 ### Publication Follow-up
 
-- publish local issue drafts to GitLab
-- replace draft references with real IDs
-
+- keep local issue-card drafts aligned with GitHub issues
+- merge this docs package into `main-dev`

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-test-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-test-plan.md
@@ -1,0 +1,49 @@
+# V2 Minute Autoresearch — Test Plan
+
+## Mission
+
+Prove the planning package is structurally sound and aligned to the clarified architecture before any implementation begins.
+
+## Verification Families
+
+### Planning integrity
+
+- [ ] one canonical docs root only
+- [ ] umbrella + child issue drafts exist
+- [ ] all child issues map to sprint docs
+- [ ] merge target is documented as `main-dev`
+
+### Architecture integrity
+
+- [ ] minute-level mission appears in the main plan and issue drafts
+- [ ] backtester authority appears in the main plan and issue drafts
+- [ ] TradingAgents is framed as selective borrowing, not system archetype
+- [ ] factor mining is optional, not mandatory
+
+### Publication integrity
+
+- [ ] GitLab publication blocker is explicit
+- [ ] no artifact falsely claims the issues were already published
+
+## Commands
+
+```bash
+git branch --show-current
+find docs/feature/v2-minute-autoresearch -maxdepth 3 -type f | sort
+rg -n "minute-level|autoresearch|TradingAgents|factor mining|backtester|GitLab publication blocker|main-dev" docs/feature/v2-minute-autoresearch -S
+```
+
+## Update Space
+
+### Command Results
+
+- leave blank until verification run
+
+### Blockers
+
+- leave blank until verification run
+
+### Follow-ups
+
+- publish issue-card drafts to GitLab later
+

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-test-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-test-plan.md
@@ -22,15 +22,15 @@ Prove the planning package is structurally sound and aligned to the clarified ar
 
 ### Publication integrity
 
-- [ ] GitLab publication blocker is explicit
-- [ ] no artifact falsely claims the issues were already published
+- [ ] GitHub issue links are present and correct
+- [ ] no artifact falsely claims the issues are unpublished drafts
 
 ## Commands
 
 ```bash
 git branch --show-current
 find docs/feature/v2-minute-autoresearch -maxdepth 3 -type f | sort
-rg -n "minute-level|autoresearch|TradingAgents|factor mining|backtester|GitLab publication blocker|main-dev" docs/feature/v2-minute-autoresearch -S
+rg -n "minute-level|autoresearch|TradingAgents|factor mining|backtester|#17|#18|#19|#20|#21|main-dev" docs/feature/v2-minute-autoresearch -S
 ```
 
 ## Update Space
@@ -45,5 +45,4 @@ rg -n "minute-level|autoresearch|TradingAgents|factor mining|backtester|GitLab p
 
 ### Follow-ups
 
-- publish issue-card drafts to GitLab later
-
+- keep local draft issue cards aligned with GitHub


### PR DESCRIPTION
## Summary

This PR adds the canonical planning workspace for the clarified V2 minute-level autoresearch architecture.

It includes:
- a dedicated docs workspace under `docs/feature/v2-minute-autoresearch/`
- one umbrella issue package plus four child workstream issue cards
- sprint1–sprint4 backend/infra execution docs
- published GitHub issue links for the new issue set

## Published GitHub issues

- #17 — V2 minute autoresearch architecture
- #18 — Autoresearch core + idea intake for V2 minute autoresearch
- #19 — Minute runtime + validation alignment for V2 minute autoresearch
- #20 — Strategy-facing stock discussion lane for V2 minute autoresearch
- #21 — Optional factor-mining lane for V2 minute autoresearch

## Notes

- This PR is planning/docs only.
- The architecture source of truth is `.omx/specs/deep-interview-spec-vs-impl.md`.
- Execution is expected to follow the generated sprint docs rather than inventing a new planning root.
