### PR TITLE
fix(issue-18): align candidate generation with keep/revert handoff

### DIFF
--- a/src/memory/candidate_generation.py
+++ b/src/memory/candidate_generation.py
@@ -1,4 +1,5 @@
 import re
+from hashlib import sha1
 from typing import Any
 
 
@@ -102,9 +103,26 @@ def build_candidate_strategy_hypothesis(
         f"using {seed_type} '{seed_value}', the minute strategy should {expected_effect} "
         f"because {market_summary}"
     )
+    structured_context = {
+        "path": str(idea_path),
+        "source": idea_source,
+        "title": idea_title,
+        "query": idea_context.get("query"),
+        "topic": idea_context.get("topic"),
+        "tickers": _coerce_tickers(idea_context.get("tickers")),
+    }
+    candidate_id = "cand-" + sha1(
+        f"{structured_context['path']}|{change['change_mode']}|{change['target_component']}".encode()
+    ).hexdigest()[:12]
+    change_summary = (
+        f"{change['change_mode']} via {change['target_component']} "
+        f"from {seed_type} '{seed_value}'"
+    )
 
     return {
+        "candidate_id": candidate_id,
         "hypothesis": hypothesis,
+        "change_summary": change_summary,
         "change_mode": change["change_mode"],
         "target_component": change["target_component"],
         "matched_terms": change["matched_terms"],
@@ -112,13 +130,14 @@ def build_candidate_strategy_hypothesis(
         "validation_status": "pending_backtest",
         "validation_rule": "backtester_required",
         "keep_revert_basis": "not_decided",
+        "structured_context": structured_context,
         "idea_reference": {
-            "path": str(idea_path),
-            "source": idea_source,
-            "title": idea_title,
+            "path": structured_context["path"],
+            "source": structured_context["source"],
+            "title": structured_context["title"],
             "seed_type": seed_type,
             "seed_value": seed_value,
-            "tickers": _coerce_tickers(idea_context.get("tickers")),
+            "tickers": structured_context["tickers"],
         },
         "market_context": {
             "source": market_source,

--- a/tests/unit/test_idea_keep_revert.py
+++ b/tests/unit/test_idea_keep_revert.py
@@ -3,6 +3,7 @@ from memory.idea_keep_revert import (
     build_iteration_record,
     decide_keep_revert,
 )
+from memory.candidate_generation import build_candidate_strategy_hypothesis
 
 
 def _candidate() -> dict:
@@ -143,4 +144,45 @@ def test_build_iteration_record_lists_required_outputs():
             "results_tsv": "experiments/results.tsv",
             "experiment_note": "vault/experiments/2026-04-09-volume-breakout.md",
         },
+    }
+
+
+def test_build_backtest_handoff_accepts_candidate_generation_output_without_adapter():
+    candidate = build_candidate_strategy_hypothesis(
+        idea_context={
+            "path": "vault/research/2026-04-09-intraday-momentum.md",
+            "source": "research",
+            "title": "Intraday Momentum",
+            "query": "intraday momentum",
+            "tickers": ["AAPL"],
+        },
+        market_context={
+            "source": "analyze:AAPL",
+            "summary": "AAPL keeps extending after opening liquidity bursts.",
+            "expected_effect": "improve risk-adjusted returns during high-liquidity windows",
+        },
+        strategy_context={
+            "strategy_path": "src/strategies/active_strategy.py",
+            "baseline_sharpe": 0.45,
+            "components": ["momentum entry", "volume-ranked universe"],
+            "results_summary": "Baseline momentum beats passive only when liquidity stays elevated.",
+        },
+    )
+
+    handoff = build_backtest_handoff(
+        candidate,
+        analysis_note={"path": "vault/analysis/2026-04-09-aapl.md", "title": "AAPL Analysis"},
+        strategy_path="src/strategies/active_strategy.py",
+        previous_best=0.62,
+    )
+
+    assert handoff["candidate_id"].startswith("cand-")
+    assert handoff["change_summary"]
+    assert handoff["idea_trace"] == {
+        "path": "vault/research/2026-04-09-intraday-momentum.md",
+        "source": "research",
+        "title": "Intraday Momentum",
+        "query": "intraday momentum",
+        "topic": None,
+        "tickers": ["AAPL"],
     }


### PR DESCRIPTION
## Summary

This PR fixes the remaining Sprint 1 contract mismatch identified during code review.

It makes `build_candidate_strategy_hypothesis()` directly consumable by `build_backtest_handoff()` by adding the canonical bridge fields:
- `structured_context`
- `candidate_id`
- `change_summary`

It preserves `idea_reference` for compatibility with any existing readers.

## Related issue

- #18

## Verification

- `uv run pytest tests/unit/test_idea_intake.py tests/unit/test_idea_search_policy.py tests/unit/test_idea_keep_revert.py tests/unit/test_candidate_generation.py tests/unit/test_program_guidance.py tests/unit/test_cli.py tests/unit/test_backtester_v2.py -q`
  - `84 passed`
- `uv run python -m compileall src config cli.py`
  - completed without compile errors

## Notes

- This is a narrow follow-up fix on top of the already-merged issue #18 work.
- No higher-level runtime loop is wired to these helpers yet; end-to-end integration remains future work.
