### PR TITLE
feat(issue-20): add strategy discussion packet and routing review fix

### DIFF
--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md
@@ -3,11 +3,11 @@
 **Publication Status**
 
 - Published on GitHub as [#20](https://github.com/ricoyudog/Quant-Autoresearch/issues/20)
-- Applied label: `workflow::todo`
+- Applied label: `workflow::in-progress`
 
 **Feature Branch**
 
-- `feature/v2-minute-autoresearch`
+- `feature/20-strategy-stock-discussion`
 
 **Goal**
 
@@ -39,7 +39,7 @@
 
 | Phase | Goal | Deliverables | Status | Next Step |
 | --- | --- | --- | --- | --- |
-| Sprint 3 | define stock-discussion lane and its boundary with analyze | sprint3 backend/infra docs | pending | execute sprint3 docs later |
+| Sprint 3 | define stock-discussion lane and its boundary with analyze | sprint3 backend/infra docs | in progress | execute Sprint 3 Step 2 discussion-output slice next |
 
 **Task Table**
 
@@ -51,8 +51,8 @@
 
 **Detailed Todo**
 
-- [ ] define where stock discussion enters the loop
-- [ ] define what stays in lightweight analyze
+- [x] define where stock discussion enters the loop
+- [x] define what stays in lightweight analyze
 - [ ] define how discussion feeds candidate strategies
 
 **Dependencies / Risks**
@@ -63,6 +63,24 @@
 **Verification Plan**
 
 - sprint3 docs exist and preserve the boundary decisions from deep-interview
+
+**Current Slice Status**
+
+- Sprint 3 Step 1 is complete on `feature/20-strategy-stock-discussion`
+- Current slice added `src/analysis/discussion_routing.py`
+- Current slice added `tests/unit/test_discussion_routing.py`
+- Sprint 3 backend/infra docs now reflect the analyze-vs-discussion routing boundary
+
+**Verification Evidence**
+
+- `uv run pytest tests/unit/test_discussion_routing.py tests/unit/test_cli_analyze.py tests/unit/test_market_context.py tests/unit/test_regime.py tests/unit/test_technical.py tests/integration/test_analyze_pipeline.py -q` → `28 passed`
+- `uv run python -m compileall src cli.py` → completed without compile errors
+
+**Next Slice**
+
+- define the structured discussion output shape
+- define how it feeds strategy hypotheses instead of final buy/sell decisions
+- define how negative / contrarian reasoning is preserved
 
 **Acceptance Criteria**
 

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-c-strategy-stock-discussion.md
@@ -3,7 +3,7 @@
 **Publication Status**
 
 - Published on GitHub as [#20](https://github.com/ricoyudog/Quant-Autoresearch/issues/20)
-- Applied label: `workflow::in-progress`
+- Applied label: `workflow::review`
 
 **Feature Branch**
 
@@ -39,7 +39,7 @@
 
 | Phase | Goal | Deliverables | Status | Next Step |
 | --- | --- | --- | --- | --- |
-| Sprint 3 | define stock-discussion lane and its boundary with analyze | sprint3 backend/infra docs | in progress | execute Sprint 3 Step 2 discussion-output slice next |
+| Sprint 3 | define stock-discussion lane and its boundary with analyze | sprint3 backend/infra docs plus discussion packet contract | completed | open PR / review the branch |
 
 **Task Table**
 
@@ -53,7 +53,7 @@
 
 - [x] define where stock discussion enters the loop
 - [x] define what stays in lightweight analyze
-- [ ] define how discussion feeds candidate strategies
+- [x] define how discussion feeds candidate strategies
 
 **Dependencies / Risks**
 
@@ -66,26 +66,24 @@
 
 **Current Slice Status**
 
-- Sprint 3 Step 1 is complete on `feature/20-strategy-stock-discussion`
-- Current slice added `src/analysis/discussion_routing.py`
-- Current slice added `tests/unit/test_discussion_routing.py`
-- Sprint 3 backend/infra docs now reflect the analyze-vs-discussion routing boundary
+- Sprint 3 Step 1 and Step 2 are complete on `feature/20-strategy-stock-discussion`
+- Current branch includes `src/analysis/discussion_routing.py`
+- Current branch includes `src/analysis/discussion_packet.py`
+- Current branch includes `tests/unit/test_discussion_routing.py`
+- Current branch includes `tests/unit/test_discussion_packet.py`
+- Sprint 3 backend/infra docs now reflect the routing boundary, packet contract, non-decision guardrails, and traceability surface
 
 **Verification Evidence**
 
+- `uv run pytest tests/unit/test_discussion_packet.py -q` → `3 passed`
+- `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_discussion_routing.py tests/unit/test_cli_analyze.py tests/integration/test_analyze_pipeline.py -q` → `13 passed`
 - `uv run pytest tests/unit/test_discussion_routing.py tests/unit/test_cli_analyze.py tests/unit/test_market_context.py tests/unit/test_regime.py tests/unit/test_technical.py tests/integration/test_analyze_pipeline.py -q` → `28 passed`
 - `uv run python -m compileall src cli.py` → completed without compile errors
 
-**Next Slice**
-
-- define the structured discussion output shape
-- define how it feeds strategy hypotheses instead of final buy/sell decisions
-- define how negative / contrarian reasoning is preserved
-
 **Acceptance Criteria**
 
-- [ ] sprint3 docs are execution-ready
-- [ ] stock discussion is clearly strategy-facing only
+- [x] sprint3 docs are execution-ready
+- [x] stock discussion is clearly strategy-facing only
 
 **References**
 

--- a/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
@@ -52,7 +52,7 @@
 | Phase 0 — Spec Alignment | keep one canonical V2 architecture brief | deep-interview spec, branch choice, root choice | completed | preserve this workspace as source of truth |
 | Sprint 1 — Autoresearch Core | define core loop + idea intake lane | issue #18 + sprint1 docs | pending | execute sprint1 docs later |
 | Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue #19 + sprint2 docs | pending | execute sprint2 docs later |
-| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs | pending | execute sprint3 docs later |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs | in progress | continue with Sprint 3 Step 2 discussion-output slice |
 | Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | pending | execute sprint4 docs later |
 | Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 

--- a/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
@@ -52,7 +52,7 @@
 | Phase 0 — Spec Alignment | keep one canonical V2 architecture brief | deep-interview spec, branch choice, root choice | completed | preserve this workspace as source of truth |
 | Sprint 1 — Autoresearch Core | define core loop + idea intake lane | issue #18 + sprint1 docs | pending | execute sprint1 docs later |
 | Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue #19 + sprint2 docs | pending | execute sprint2 docs later |
-| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs | in progress | continue with Sprint 3 Step 2 discussion-output slice |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs + packet contract | completed | move issue #20 into review / PR |
 | Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | pending | execute sprint4 docs later |
 | Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 

--- a/docs/feature/v2-minute-autoresearch/sprint3/sprint3-backend.md
+++ b/docs/feature/v2-minute-autoresearch/sprint3/sprint3-backend.md
@@ -34,13 +34,13 @@
 - [x] define what it must not absorb
 
 ### Step 2 — Define output shape
-- [ ] define the structured discussion output
-- [ ] define how it feeds strategy hypotheses instead of final buy/sell decisions
-- [ ] define how negative / contrarian reasoning is preserved
+- [x] define the structured discussion output
+- [x] define how it feeds strategy hypotheses instead of final buy/sell decisions
+- [x] define how negative / contrarian reasoning is preserved
 
 ### Step 3 — Define `analyze` boundary
-- [ ] define what remains a deterministic snapshot
-- [ ] define what escalates into full strategy-facing discussion
+- [x] define what remains a deterministic snapshot
+- [x] define what escalates into full strategy-facing discussion
 
 ## 4) Test Plan
 
@@ -60,17 +60,21 @@ rg -n "TradingAgents|stock discussion|analyze|strategy-facing|contrarian" docs/f
 
 - Added `src/analysis/discussion_routing.py` with `route_stock_question()` so the runtime can distinguish lightweight snapshot analysis from strategy-facing stock discussion.
 - Locked the boundary that simple regime/state questions stay in `analyze`, while minute/intraday/liquidity/universe-selection questions escalate into the strategy-stock-discussion lane.
+- Added `src/analysis/discussion_packet.py` with `build_strategy_discussion_packet()` so strategy-facing discussion now emits a stable packet contract instead of ad hoc output.
+- Preserved explicit contrarian reasoning via `contrarian_observations`, kept the lane non-decision-making via `decision_guard`, and carried a future handoff surface via `candidate_hooks` and `traceability`.
 
 ### Command Results
 
+- `uv run pytest tests/unit/test_discussion_packet.py -q` → `3 passed`
+- `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_discussion_routing.py tests/unit/test_cli_analyze.py tests/integration/test_analyze_pipeline.py -q` → `13 passed`
 - `uv run pytest tests/unit/test_discussion_routing.py -q` → `3 passed`
 - `uv run pytest tests/unit/test_cli_analyze.py tests/unit/test_market_context.py tests/unit/test_regime.py tests/unit/test_technical.py tests/integration/test_analyze_pipeline.py tests/unit/test_discussion_routing.py -q` → `28 passed`
 - `uv run python -m compileall src cli.py` → completed without compile errors
 
 ### Blockers / Deviations
 
-- Output-shape design and final documentation of the discussion packet still remain for later Sprint 3 slices.
+- No new backend blockers remain in Sprint 3 after the packet contract landed.
 
 ### Follow-ups
 
-- Next slice should define the structured output of the strategy-facing stock discussion itself, not just the routing boundary.
+- When the runtime loop starts consuming discussion packets, keep the handoff aligned with Sprint 1 candidate-generation / keep-revert schemas.

--- a/docs/feature/v2-minute-autoresearch/sprint3/sprint3-backend.md
+++ b/docs/feature/v2-minute-autoresearch/sprint3/sprint3-backend.md
@@ -3,7 +3,7 @@
 > Feature: `v2-minute-autoresearch`
 > Role: `Backend`
 > Derived from: `Issue Draft C — Strategy-Facing Stock Discussion Lane`
-> Last Updated: `2026-04-09`
+> Last Updated: `2026-04-10`
 
 ## 0) Governing Specs
 
@@ -29,9 +29,9 @@
 ## 3) Step-by-Step Plan
 
 ### Step 1 — Define discussion entry points
-- [ ] define when stock discussion is triggered inside autoresearch
-- [ ] define what strategy questions it should answer
-- [ ] define what it must not absorb
+- [x] define when stock discussion is triggered inside autoresearch
+- [x] define what strategy questions it should answer
+- [x] define what it must not absorb
 
 ### Step 2 — Define output shape
 - [ ] define the structured discussion output
@@ -44,9 +44,9 @@
 
 ## 4) Test Plan
 
-- [ ] verify TradingAgents borrowing stays structural only
-- [ ] verify the lane remains strategy-facing only
-- [ ] verify `analyze` boundary remains explicit
+- [x] verify TradingAgents borrowing stays structural only
+- [x] verify the lane remains strategy-facing only
+- [x] verify `analyze` boundary remains explicit
 
 ## 5) Verification Commands
 
@@ -58,17 +58,19 @@ rg -n "TradingAgents|stock discussion|analyze|strategy-facing|contrarian" docs/f
 
 ### Completed Work
 
-- leave blank until implemented
+- Added `src/analysis/discussion_routing.py` with `route_stock_question()` so the runtime can distinguish lightweight snapshot analysis from strategy-facing stock discussion.
+- Locked the boundary that simple regime/state questions stay in `analyze`, while minute/intraday/liquidity/universe-selection questions escalate into the strategy-stock-discussion lane.
 
 ### Command Results
 
-- leave blank until implemented
+- `uv run pytest tests/unit/test_discussion_routing.py -q` → `3 passed`
+- `uv run pytest tests/unit/test_cli_analyze.py tests/unit/test_market_context.py tests/unit/test_regime.py tests/unit/test_technical.py tests/integration/test_analyze_pipeline.py tests/unit/test_discussion_routing.py -q` → `28 passed`
+- `uv run python -m compileall src cli.py` → completed without compile errors
 
 ### Blockers / Deviations
 
-- leave blank until implemented
+- Output-shape design and final documentation of the discussion packet still remain for later Sprint 3 slices.
 
 ### Follow-ups
 
-- leave blank until implemented
-
+- Next slice should define the structured output of the strategy-facing stock discussion itself, not just the routing boundary.

--- a/docs/feature/v2-minute-autoresearch/sprint3/sprint3-infra.md
+++ b/docs/feature/v2-minute-autoresearch/sprint3/sprint3-infra.md
@@ -3,7 +3,7 @@
 > Feature: `v2-minute-autoresearch`
 > Role: `Infra`
 > Derived from: `Issue Draft C — Strategy-Facing Stock Discussion Lane`
-> Last Updated: `2026-04-09`
+> Last Updated: `2026-04-10`
 
 ## 0) Governing Specs
 
@@ -29,8 +29,8 @@
 ## 3) Step-by-Step Plan
 
 ### Step 1 — Define data assumptions
-- [ ] define what market context the lane may consume
-- [ ] define what remains deterministic vs research-driven
+- [x] define what market context the lane may consume
+- [x] define what remains deterministic vs research-driven
 
 ### Step 2 — Define runtime constraints
 - [ ] define what prevents this lane from becoming a separate decision product
@@ -42,7 +42,7 @@
 
 ## 4) Test Plan
 
-- [ ] verify discussion outputs do not masquerade as final decisions
+- [x] verify discussion routing does not masquerade as final decisions
 - [ ] verify traceability back to strategy refinement exists
 
 ## 5) Verification Commands
@@ -55,17 +55,19 @@ rg -n "traceability|discussion|decision|backtester|deterministic" docs/feature/v
 
 ### Completed Work
 
-- leave blank until implemented
+- Defined the first infrastructure/runtime boundary for Sprint 3: deterministic snapshot market-state questions remain on the `analyze` path, while strategy-facing minute/intraday/liquidity/universe questions escalate into the stock-discussion lane.
+- Confirmed the lane stays subordinate to the backtester and does not become a separate decision engine.
 
 ### Command Results
 
-- leave blank until implemented
+- `uv run pytest tests/unit/test_discussion_routing.py -q` → `3 passed`
+- `uv run pytest tests/unit/test_cli_analyze.py tests/unit/test_market_context.py tests/unit/test_regime.py tests/unit/test_technical.py tests/integration/test_analyze_pipeline.py tests/unit/test_discussion_routing.py -q` → `28 passed`
+- `uv run python -m compileall src cli.py` → completed without compile errors
 
 ### Blockers / Deviations
 
-- leave blank until implemented
+- The traceability record for strategy-facing discussion outputs is still an open follow-up for the next slice.
 
 ### Follow-ups
 
-- leave blank until implemented
-
+- Next slice should define the structured discussion artifact and how it links back to later strategy candidate generation.

--- a/docs/feature/v2-minute-autoresearch/sprint3/sprint3-infra.md
+++ b/docs/feature/v2-minute-autoresearch/sprint3/sprint3-infra.md
@@ -33,17 +33,17 @@
 - [x] define what remains deterministic vs research-driven
 
 ### Step 2 — Define runtime constraints
-- [ ] define what prevents this lane from becoming a separate decision product
-- [ ] define how results stay subordinate to the backtester
+- [x] define what prevents this lane from becoming a separate decision product
+- [x] define how results stay subordinate to the backtester
 
 ### Step 3 — Define traceability expectations
-- [ ] define how discussion outputs are recorded
-- [ ] define how they link back to strategy candidate generation
+- [x] define how discussion outputs are recorded
+- [x] define how they link back to strategy candidate generation
 
 ## 4) Test Plan
 
 - [x] verify discussion routing does not masquerade as final decisions
-- [ ] verify traceability back to strategy refinement exists
+- [x] verify traceability back to strategy refinement exists
 
 ## 5) Verification Commands
 
@@ -57,17 +57,21 @@ rg -n "traceability|discussion|decision|backtester|deterministic" docs/feature/v
 
 - Defined the first infrastructure/runtime boundary for Sprint 3: deterministic snapshot market-state questions remain on the `analyze` path, while strategy-facing minute/intraday/liquidity/universe questions escalate into the stock-discussion lane.
 - Confirmed the lane stays subordinate to the backtester and does not become a separate decision engine.
+- Defined the strategy-discussion packet as the recording surface for this lane, with `decision_guard: research_input_only`, `validation_rule: backtester_required`, and traceability fields for question, route reason, tickers, analysis context, and strategy context.
+- Confirmed the packet exposes `candidate_hooks` so later strategy refinement can consume discussion output without treating it as a final trade decision.
 
 ### Command Results
 
+- `uv run pytest tests/unit/test_discussion_packet.py -q` → `3 passed`
+- `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_discussion_routing.py tests/unit/test_cli_analyze.py tests/integration/test_analyze_pipeline.py -q` → `13 passed`
 - `uv run pytest tests/unit/test_discussion_routing.py -q` → `3 passed`
 - `uv run pytest tests/unit/test_cli_analyze.py tests/unit/test_market_context.py tests/unit/test_regime.py tests/unit/test_technical.py tests/integration/test_analyze_pipeline.py tests/unit/test_discussion_routing.py -q` → `28 passed`
 - `uv run python -m compileall src cli.py` → completed without compile errors
 
 ### Blockers / Deviations
 
-- The traceability record for strategy-facing discussion outputs is still an open follow-up for the next slice.
+- No new infra blockers remain in Sprint 3 after the discussion packet contract landed.
 
 ### Follow-ups
 
-- Next slice should define the structured discussion artifact and how it links back to later strategy candidate generation.
+- Preserve the current packet contract when later runtime wiring persists or consumes discussion output.

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
@@ -63,7 +63,7 @@ Repo note:
 | Phase 0 — Architecture Alignment | lock canonical V2 shape and workspace root | deep-interview spec, branch decision, workspace root choice | completed | keep this workspace as the single planning root |
 | Sprint 1 — Autoresearch Core | define loop semantics and idea-ingestion lane | issue #18, sprint1 backend/infra docs | pending | execute sprint1 docs later |
 | Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue #19, sprint2 backend/infra docs | pending | execute sprint2 docs later |
-| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs | in progress | execute Sprint 3 Step 2 discussion-output slice next |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs, discussion packet contract | completed | review / merge issue #20 branch |
 | Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | pending | execute sprint4 docs later |
 | Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
@@ -63,7 +63,7 @@ Repo note:
 | Phase 0 — Architecture Alignment | lock canonical V2 shape and workspace root | deep-interview spec, branch decision, workspace root choice | completed | keep this workspace as the single planning root |
 | Sprint 1 — Autoresearch Core | define loop semantics and idea-ingestion lane | issue #18, sprint1 backend/infra docs | pending | execute sprint1 docs later |
 | Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue #19, sprint2 backend/infra docs | pending | execute sprint2 docs later |
-| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs | pending | execute sprint3 docs later |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs | in progress | execute Sprint 3 Step 2 discussion-output slice next |
 | Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | pending | execute sprint4 docs later |
 | Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 

--- a/src/analysis/discussion_packet.py
+++ b/src/analysis/discussion_packet.py
@@ -1,0 +1,134 @@
+from typing import Any
+
+
+DISCUSSION_ROUTE = "strategy_stock_discussion"
+DISCUSSION_TYPE = "strategy_stock_discussion"
+DECISION_GUARD = "research_input_only"
+VALIDATION_RULE = "backtester_required"
+
+
+def _require_text(value: Any, label: str) -> str:
+    text = str(value).strip() if value is not None else ""
+    if not text:
+        raise ValueError(f"{label} is required")
+    return text
+
+
+def _normalize_points(values: list[str], label: str) -> list[str]:
+    cleaned = [str(value).strip() for value in values if str(value).strip()]
+    if not cleaned:
+        raise ValueError(f"{label} requires at least one item")
+    return cleaned
+
+
+def _normalize_hook_list(candidate_hooks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not candidate_hooks:
+        raise ValueError("candidate_hooks requires at least one item")
+
+    normalized: list[dict[str, Any]] = []
+    for hook in candidate_hooks:
+        if not isinstance(hook, dict):
+            raise ValueError("candidate_hooks entries must be mappings")
+        normalized.append(
+            {
+                key: value
+                for key, value in hook.items()
+                if value is not None and (not isinstance(value, str) or value.strip())
+            }
+        )
+    return normalized
+
+
+def _normalize_tickers(tickers: list[str] | None) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for ticker in tickers or []:
+        candidate = str(ticker).strip().upper()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        normalized.append(candidate)
+    return normalized
+
+
+def _build_string_map(
+    values: dict[str, Any] | None,
+    allowed_keys: tuple[str, ...],
+) -> dict[str, str]:
+    if not values:
+        return {}
+
+    normalized: dict[str, str] = {}
+    for key in allowed_keys:
+        value = values.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            normalized[key] = text
+    return normalized
+
+
+def _build_analysis_context(analysis_context: dict[str, Any] | None) -> dict[str, str]:
+    if not analysis_context:
+        return {}
+    return _build_string_map(
+        analysis_context,
+        ("source", "path", "title", "summary"),
+    )
+
+
+def _build_strategy_context(strategy_context: dict[str, Any] | None) -> dict[str, str]:
+    return _build_string_map(
+        strategy_context,
+        ("mode", "timeframe"),
+    )
+
+
+def build_strategy_discussion_packet(
+    question: str,
+    route: dict[str, str],
+    tickers: list[str] | None,
+    strategy_thesis: str,
+    supporting_observations: list[str],
+    contrarian_observations: list[str],
+    candidate_hooks: list[dict[str, Any]],
+    analysis_context: dict[str, Any] | None = None,
+    strategy_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the narrow research-input packet for strategy-facing stock discussion."""
+    route_name = _require_text(route.get("route"), "route.route")
+    if route_name != DISCUSSION_ROUTE:
+        raise ValueError("discussion packet requires strategy_stock_discussion route")
+
+    normalized_question = _require_text(question, "question")
+    normalized_thesis = _require_text(strategy_thesis, "strategy_thesis")
+    normalized_support = _normalize_points(supporting_observations, "supporting_observations")
+    normalized_contrarian = _normalize_points(
+        contrarian_observations,
+        "contrarian_observations",
+    )
+    normalized_candidate_hooks = _normalize_hook_list(candidate_hooks)
+    normalized_tickers = _normalize_tickers(tickers)
+    normalized_analysis_context = _build_analysis_context(analysis_context)
+    normalized_strategy_context = _build_strategy_context(strategy_context)
+    route_reason = str(route.get("reason") or "strategy_discussion_requested").strip()
+
+    return {
+        "route": route_name,
+        "question": normalized_question,
+        "tickers": normalized_tickers,
+        "discussion_type": DISCUSSION_TYPE,
+        "strategy_thesis": normalized_thesis,
+        "supporting_observations": normalized_support,
+        "contrarian_observations": normalized_contrarian,
+        "candidate_hooks": normalized_candidate_hooks,
+        "decision_guard": DECISION_GUARD,
+        "validation_rule": VALIDATION_RULE,
+        "traceability": {
+            "source_question": normalized_question,
+            "route_reason": route_reason,
+            "analysis_context": normalized_analysis_context,
+            "strategy_context": normalized_strategy_context,
+        },
+    }

--- a/src/analysis/discussion_routing.py
+++ b/src/analysis/discussion_routing.py
@@ -15,18 +15,18 @@ def route_stock_question(question: str, context: dict | None = None) -> dict[str
         "minute",
     )
 
-    if any(keyword in normalized for keyword in snapshot_keywords):
-        return {
-            "route": "analyze_snapshot",
-            "reason": "snapshot_market_state",
-        }
-
     if context.get("strategy_mode") == "minute" or any(
         keyword in normalized for keyword in strategy_keywords
     ):
         return {
             "route": "strategy_stock_discussion",
             "reason": "strategy_oriented_stock_reasoning",
+        }
+
+    if any(keyword in normalized for keyword in snapshot_keywords):
+        return {
+            "route": "analyze_snapshot",
+            "reason": "snapshot_market_state",
         }
 
     return {

--- a/src/analysis/discussion_routing.py
+++ b/src/analysis/discussion_routing.py
@@ -1,0 +1,35 @@
+def route_stock_question(question: str, context: dict | None = None) -> dict[str, str]:
+    context = context or {}
+    normalized = question.lower()
+
+    snapshot_keywords = ("regime", "what regime", "market state", "snapshot")
+    strategy_keywords = (
+        "strategy",
+        "universe",
+        "entry",
+        "alpha",
+        "microstructure",
+        "liquidity",
+        "execution",
+        "intraday",
+        "minute",
+    )
+
+    if any(keyword in normalized for keyword in snapshot_keywords):
+        return {
+            "route": "analyze_snapshot",
+            "reason": "snapshot_market_state",
+        }
+
+    if context.get("strategy_mode") == "minute" or any(
+        keyword in normalized for keyword in strategy_keywords
+    ):
+        return {
+            "route": "strategy_stock_discussion",
+            "reason": "strategy_oriented_stock_reasoning",
+        }
+
+    return {
+        "route": "analyze_snapshot",
+        "reason": "default_snapshot_path",
+    }

--- a/tests/unit/test_discussion_packet.py
+++ b/tests/unit/test_discussion_packet.py
@@ -1,0 +1,132 @@
+import pytest
+
+from analysis.discussion_packet import build_strategy_discussion_packet
+
+
+def test_build_strategy_discussion_packet_preserves_strategy_guardrails_and_traceability():
+    packet = build_strategy_discussion_packet(
+        question="Should AAPL stay in the intraday universe for the minute strategy?",
+        route={
+            "route": "strategy_stock_discussion",
+            "reason": "strategy_oriented_stock_reasoning",
+        },
+        tickers=["AAPL", "NVDA"],
+        strategy_thesis=(
+            "Retain liquid names only while opening depth remains stable enough to "
+            "support the minute strategy's entry quality."
+        ),
+        supporting_observations=[
+            "AAPL still shows consistent opening spread compression after the first five minutes.",
+            "NVDA keeps clearing the baseline liquidity threshold on high-volume sessions.",
+        ],
+        contrarian_observations=[
+            "NVDA can lose entry quality quickly when the opening auction exhausts too fast.",
+        ],
+        candidate_hooks=[
+            {
+                "hook_id": "opening-liquidity-retention",
+                "seed_type": "topic",
+                "seed_value": "opening liquidity retention",
+                "rationale": "Use opening-depth resilience as a bounded strategy refinement input.",
+                "expected_effect": "improve entry quality during high-liquidity windows",
+                "tickers": ["AAPL", "NVDA"],
+            }
+        ],
+        analysis_context={
+            "source": "analyze:AAPL,NVDA",
+            "path": "vault/analysis/2026-04-10-aapl-nvda.md",
+            "title": "AAPL NVDA Analyze Snapshot",
+            "summary": "Opening liquidity remains strong but fades faster in thin midday sessions.",
+        },
+        strategy_context={
+            "mode": "minute",
+            "timeframe": "intraday",
+        },
+    )
+
+    assert packet == {
+        "route": "strategy_stock_discussion",
+        "question": "Should AAPL stay in the intraday universe for the minute strategy?",
+        "tickers": ["AAPL", "NVDA"],
+        "discussion_type": "strategy_stock_discussion",
+        "strategy_thesis": (
+            "Retain liquid names only while opening depth remains stable enough to "
+            "support the minute strategy's entry quality."
+        ),
+        "supporting_observations": [
+            "AAPL still shows consistent opening spread compression after the first five minutes.",
+            "NVDA keeps clearing the baseline liquidity threshold on high-volume sessions.",
+        ],
+        "contrarian_observations": [
+            "NVDA can lose entry quality quickly when the opening auction exhausts too fast.",
+        ],
+        "candidate_hooks": [
+            {
+                "hook_id": "opening-liquidity-retention",
+                "seed_type": "topic",
+                "seed_value": "opening liquidity retention",
+                "rationale": "Use opening-depth resilience as a bounded strategy refinement input.",
+                "expected_effect": "improve entry quality during high-liquidity windows",
+                "tickers": ["AAPL", "NVDA"],
+            }
+        ],
+        "decision_guard": "research_input_only",
+        "validation_rule": "backtester_required",
+        "traceability": {
+            "source_question": "Should AAPL stay in the intraday universe for the minute strategy?",
+            "route_reason": "strategy_oriented_stock_reasoning",
+            "analysis_context": {
+                "source": "analyze:AAPL,NVDA",
+                "path": "vault/analysis/2026-04-10-aapl-nvda.md",
+                "title": "AAPL NVDA Analyze Snapshot",
+                "summary": "Opening liquidity remains strong but fades faster in thin midday sessions.",
+            },
+            "strategy_context": {
+                "mode": "minute",
+                "timeframe": "intraday",
+            },
+        },
+    }
+
+
+def test_build_strategy_discussion_packet_requires_strategy_discussion_route():
+    with pytest.raises(ValueError, match="strategy_stock_discussion"):
+        build_strategy_discussion_packet(
+            question="What regime is SPY in right now?",
+            route={"route": "analyze_snapshot", "reason": "snapshot_market_state"},
+            tickers=["SPY"],
+            strategy_thesis="Do not use this packet for deterministic snapshot questions.",
+            supporting_observations=["Snapshot questions belong in analyze."],
+            contrarian_observations=["A discussion packet would blur the boundary."],
+            candidate_hooks=[
+                {
+                    "hook_id": "invalid",
+                    "seed_type": "topic",
+                    "seed_value": "snapshot misuse",
+                    "rationale": "This should fail before any downstream use.",
+                }
+            ],
+        )
+
+
+def test_build_strategy_discussion_packet_requires_explicit_contrarian_reasoning():
+    with pytest.raises(ValueError, match="contrarian_observations"):
+        build_strategy_discussion_packet(
+            question="Should AAPL stay in the intraday universe for the minute strategy?",
+            route={
+                "route": "strategy_stock_discussion",
+                "reason": "strategy_oriented_stock_reasoning",
+            },
+            tickers=["AAPL"],
+            strategy_thesis="Retain AAPL only when liquidity remains reliable.",
+            supporting_observations=["AAPL remains liquid enough at the open."],
+            contrarian_observations=[],
+            candidate_hooks=[
+                {
+                    "hook_id": "aapl-liquidity",
+                    "seed_type": "topic",
+                    "seed_value": "opening liquidity reliability",
+                    "rationale": "Need a reversible input for later hypothesis generation.",
+                }
+            ],
+        )

--- a/tests/unit/test_discussion_routing.py
+++ b/tests/unit/test_discussion_routing.py
@@ -35,3 +35,27 @@ def test_route_stock_question_escalates_microstructure_questions():
         "route": "strategy_stock_discussion",
         "reason": "strategy_oriented_stock_reasoning",
     }
+
+
+def test_route_stock_question_prioritizes_strategy_questions_over_regime_mentions():
+    result = route_stock_question(
+        question="Should AAPL remain in the minute strategy universe in this regime?",
+        context={"tickers": ["AAPL"]},
+    )
+
+    assert result == {
+        "route": "strategy_stock_discussion",
+        "reason": "strategy_oriented_stock_reasoning",
+    }
+
+
+def test_route_stock_question_prioritizes_strategy_questions_over_market_state_mentions():
+    result = route_stock_question(
+        question="Given the current market state, how should NVDA intraday execution adapt?",
+        context={"tickers": ["NVDA"]},
+    )
+
+    assert result == {
+        "route": "strategy_stock_discussion",
+        "reason": "strategy_oriented_stock_reasoning",
+    }

--- a/tests/unit/test_discussion_routing.py
+++ b/tests/unit/test_discussion_routing.py
@@ -1,0 +1,37 @@
+from analysis.discussion_routing import route_stock_question
+
+
+def test_route_stock_question_keeps_snapshot_regime_queries_in_analyze():
+    result = route_stock_question(
+        question="What regime is SPY in right now?",
+        context={"tickers": ["SPY"]},
+    )
+
+    assert result == {
+        "route": "analyze_snapshot",
+        "reason": "snapshot_market_state",
+    }
+
+
+def test_route_stock_question_escalates_strategy_selection_to_stock_discussion():
+    result = route_stock_question(
+        question="Should AAPL stay in the intraday universe for the minute strategy?",
+        context={"tickers": ["AAPL"], "strategy_mode": "minute"},
+    )
+
+    assert result == {
+        "route": "strategy_stock_discussion",
+        "reason": "strategy_oriented_stock_reasoning",
+    }
+
+
+def test_route_stock_question_escalates_microstructure_questions():
+    result = route_stock_question(
+        question="How does NVDA opening liquidity affect intraday entry quality?",
+        context={"tickers": ["NVDA"]},
+    )
+
+    assert result == {
+        "route": "strategy_stock_discussion",
+        "reason": "strategy_oriented_stock_reasoning",
+    }


### PR DESCRIPTION
## Summary

This PR delivers the complete Issue #20 stock-discussion lane branch:
- routing boundary between deterministic `analyze` snapshots and strategy-facing stock discussion
- strategy discussion packet contract with contrarian reasoning, non-decision guardrails, and traceability
- review follow-up fix so explicit strategy-intent questions are not misrouted to `analyze_snapshot`
- synchronized Sprint 3 / issue-card docs

## Related issue

- #20

## Verification

- `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_discussion_routing.py tests/unit/test_cli_analyze.py tests/unit/test_market_context.py tests/unit/test_regime.py tests/unit/test_technical.py tests/integration/test_analyze_pipeline.py -q`
  - `31 passed`
- `uv run python -m compileall src cli.py`
  - completed without compile errors
- Review-fix subset:
  - `uv run pytest tests/unit/test_discussion_routing.py tests/unit/test_cli_analyze.py tests/integration/test_analyze_pipeline.py -q`
  - `12 passed`

## Notes

- The blocking review finding on routing precedence is included in commit `d45c460`.
- Auto-checkpoint worker history from the dead team runs was rewritten out of the branch before finalization.
