### PR TITLE
Keep minute-granularity snapshots on the analyze path

### DIFF
--- a/src/analysis/discussion_routing.py
+++ b/src/analysis/discussion_routing.py
@@ -13,11 +13,9 @@ def route_stock_question(question: str, context: dict | None = None) -> dict[str
         "liquidity",
         "execution",
     )
-    timeframe_keywords = ("intraday", "minute")
 
     has_snapshot_signal = any(keyword in normalized for keyword in snapshot_keywords)
     has_strategy_signal = any(keyword in normalized for keyword in strategy_keywords)
-    has_timeframe_signal = any(keyword in normalized for keyword in timeframe_keywords)
 
     if has_snapshot_signal and not has_strategy_signal:
         return {
@@ -25,9 +23,7 @@ def route_stock_question(question: str, context: dict | None = None) -> dict[str
             "reason": "snapshot_market_state",
         }
 
-    if (
-        context.get("strategy_mode") == "minute" and not has_snapshot_signal
-    ) or has_strategy_signal or has_timeframe_signal:
+    if has_strategy_signal:
         return {
             "route": "strategy_stock_discussion",
             "reason": "strategy_oriented_stock_reasoning",

--- a/tests/unit/test_discussion_routing.py
+++ b/tests/unit/test_discussion_routing.py
@@ -37,6 +37,42 @@ def test_route_stock_question_keeps_snapshot_queries_in_analyze_with_minute_cont
     }
 
 
+def test_route_stock_question_keeps_plain_intraday_snapshot_wording_in_analyze():
+    result = route_stock_question(
+        question="How is NVDA doing intraday right now?",
+        context={"tickers": ["NVDA"]},
+    )
+
+    assert result == {
+        "route": "analyze_snapshot",
+        "reason": "default_snapshot_path",
+    }
+
+
+def test_route_stock_question_keeps_plain_minute_chart_snapshot_wording_in_analyze():
+    result = route_stock_question(
+        question="What does the 1-minute chart look like for AAPL?",
+        context={"tickers": ["AAPL"]},
+    )
+
+    assert result == {
+        "route": "analyze_snapshot",
+        "reason": "default_snapshot_path",
+    }
+
+
+def test_route_stock_question_keeps_plain_intraday_snapshot_wording_in_analyze_with_minute_context():
+    result = route_stock_question(
+        question="How is NVDA doing intraday right now?",
+        context={"tickers": ["NVDA"], "strategy_mode": "minute"},
+    )
+
+    assert result == {
+        "route": "analyze_snapshot",
+        "reason": "default_snapshot_path",
+    }
+
+
 def test_route_stock_question_escalates_strategy_selection_to_stock_discussion():
     result = route_stock_question(
         question="Should AAPL stay in the intraday universe for the minute strategy?",


### PR DESCRIPTION
## Summary
- keep plain intraday/minute snapshot questions on `analyze_snapshot`
- require explicit strategy intent before escalating minute/intraday wording into `strategy_stock_discussion`
- add regression coverage for realistic plain-wording snapshot questions, including minute-mode context

## Why
A review found that the previous helper still over-escalated common snapshot-style questions such as:
- `How is NVDA doing intraday right now?`
- `What does the 1-minute chart look like for AAPL?`

Those should stay on the snapshot/analyze path unless the question also carries explicit strategy intent.

## Verification
- `uv run pytest tests/unit/test_discussion_routing.py tests/unit/test_cli_analyze.py tests/integration/test_analyze_pipeline.py -q` → `17 passed`
- `uv run python -m compileall src cli.py` → passed
- `git diff --check` → clean

## Review status
- follow-up code review: approved
- no blocking issues remaining
