### PR TITLE
docs(issue-21): finalize optional factor-mining sprint 4 contract

### DIFF
--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md
@@ -3,24 +3,25 @@
 **Publication Status**
 
 - Published on GitHub as [#21](https://github.com/ricoyudog/Quant-Autoresearch/issues/21)
-- Applied label: `workflow::todo`
+- Applied label: `workflow::in-progress`
 
 **Feature Branch**
 
-- `feature/v2-minute-autoresearch`
+- `feature/21-optional-factor-mining`
 
 **Goal**
 
-- Define factor mining as an optional autoresearch sub-mode that can be invoked when the main loop needs new alpha primitives/features.
+- Define factor mining as an optional autoresearch sub-mode; the current Sprint 4 slice narrows to the Step 2 candidate-integration boundary for canonical factor proposals.
 
 **Scope**
 
-- factor mining trigger criteria
-- relationship to autoresearch idea generation
-- result-based evaluation of factor usefulness
+- Step 2 promotion boundary from raw factor packets into the existing candidate-generation path
+- canonical proposal storage and traceability requirements before promotion
+- honest lineage limits from proposal creation through current keep/revert artifacts
 
 **Out of Scope**
 
+- Sprint 4 Step 3 result-based judgment semantics
 - mandatory factor mining in every loop
 - standalone factor-mining product behavior
 
@@ -39,20 +40,20 @@
 
 | Phase | Goal | Deliverables | Status | Next Step |
 | --- | --- | --- | --- | --- |
-| Sprint 4 | define optional factor-mining sub-mode | sprint4 backend/infra docs | pending | execute sprint4 docs later |
+| Sprint 4 | define the Step 2 candidate-integration boundary for optional factor mining | sprint4 backend/infra docs | in progress | execute Sprint 4 Step 3 result-judgment semantics |
 
 **Task Table**
 
 | Task ID | Task | Owner | Dependency | Effort | Acceptance |
 | --- | --- | --- | --- | --- | --- |
 | D-01 | Define trigger criteria for factor mining | BE | none | 0.1d | factor mining is clearly optional |
-| D-02 | Define how factor mining feeds candidate generation | BE | D-01 | 0.2d | factor ideas stay under autoresearch |
-| D-03 | Define runtime/data assumptions and failure boundaries | Infra | D-01 | 0.1d | assumptions are explicit |
+| D-02 | Define the Step 2 canonical proposal promotion boundary | BE | D-01 | 0.2d | raw `candidate_hooks` stay research input only until a canonical proposal passes gating |
+| D-03 | Define Step 2 storage / lineage guardrails | Infra | D-02 | 0.1d | only current persisted lineage surfaces are claimed |
 
 **Detailed Todo**
 
-- [ ] define when factor mining should be invoked
-- [ ] define how factors become strategy candidates
+- [x] define when factor mining should be invoked
+- [x] define the Step 2 canonical proposal record and promotion gating before candidate generation
 - [ ] define how factors are judged by results
 
 **Dependencies / Risks**
@@ -62,12 +63,26 @@
 
 **Verification Plan**
 
-- sprint4 docs exist and preserve the optional-submode rule
+- sprint4 docs preserve the Step 2 `packet -> canonical proposal -> candidate` boundary
+- docs and focused tests confirm the stated hook/seed gating plus current lineage ceiling
+
+**Current Slice Status**
+
+- Sprint 4 Step 2 closeout is complete and verified on `feature/21-optional-factor-mining`; Sprint 4 Step 3 remains open
+- Sprint 4 backend/infra docs now define the optional trigger criteria, the Step 2 canonical proposal record, promotion blocking rules, and the current lineage ceiling for the factor-mining lane
+- Step 2 explicitly keeps factor mining subordinate to the existing autoresearch candidate/backtest path instead of introducing a second candidate lane
+
+**Verification Evidence**
+
+- `rg -n "canonical proposal|hook_id|seed_type|candidate_hooks|traceability|contrarian_observations|candidate_id|idea_trace|analysis_context|results_tsv|experiment_note" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S` → matched the new Step 2 canonical proposal wording, hook/seed gating, and honest lineage limits
+- `rg -n "candidate_hooks|traceability|contrarian_observations|hook_id|seed_type|build_candidate_strategy_hypothesis|idea_context\\.path|idea_context\\.source|idea_context\\.title|market_context\\.source|market_context\\.summary|idea_trace|analysis_context|results_tsv|experiment_note" src tests -S` → matched the code-backed field names and current persisted lineage surfaces referenced by the docs
+- `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q` → `11 passed`
 
 **Acceptance Criteria**
 
-- [ ] sprint4 docs are execution-ready
-- [ ] factor mining is optional and results-first
+- [x] sprint4 Step 2 docs are execution-ready
+- [x] factor mining remains optional and research-input-only at promotion time
+- [x] Step 2 lineage claims stop at current persisted candidate/backtest artifacts
 
 **References**
 

--- a/docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md
@@ -3,7 +3,7 @@
 **Publication Status**
 
 - Published on GitHub as [#21](https://github.com/ricoyudog/Quant-Autoresearch/issues/21)
-- Applied label: `workflow::in-progress`
+- Applied label: `workflow::review`
 
 **Feature Branch**
 
@@ -11,17 +11,19 @@
 
 **Goal**
 
-- Define factor mining as an optional autoresearch sub-mode; the current Sprint 4 slice narrows to the Step 2 candidate-integration boundary for canonical factor proposals.
+- Define factor mining as an optional autoresearch sub-mode; the active Sprint 4 slice focuses on the Step 3 infra result/failure boundary for promoted factor-derived candidates while preserving the verified Step 2 promotion and lineage contract.
 
 **Scope**
 
-- Step 2 promotion boundary from raw factor packets into the existing candidate-generation path
-- canonical proposal storage and traceability requirements before promotion
-- honest lineage limits from proposal creation through current keep/revert artifacts
+- Step 3 infra result/failure boundary for promoted factor-derived candidates
+- failure / skip / defer boundaries after canonical promotion
+- preserving backtester-owned keep / revert authority without introducing a second evaluation lane
+- preserving the verified Step 2 promotion and lineage boundary already closed out
 
 **Out of Scope**
 
-- Sprint 4 Step 3 result-based judgment semantics
+- any new factor-specific scoring, ranking, or approval mechanism ahead of keep / revert
+- any new artifact persistence beyond the current keep / revert-facing lineage surfaces
 - mandatory factor mining in every loop
 - standalone factor-mining product behavior
 
@@ -40,7 +42,7 @@
 
 | Phase | Goal | Deliverables | Status | Next Step |
 | --- | --- | --- | --- | --- |
-| Sprint 4 | define the Step 2 candidate-integration boundary for optional factor mining | sprint4 backend/infra docs | in progress | execute Sprint 4 Step 3 result-judgment semantics |
+| Sprint 4 | define the Step 3 result-judgment semantics for optional factor mining without breaking the Step 2 promotion contract | sprint4 backend/infra docs | completed | move issue #21 to review / PR |
 
 **Task Table**
 
@@ -49,12 +51,13 @@
 | D-01 | Define trigger criteria for factor mining | BE | none | 0.1d | factor mining is clearly optional |
 | D-02 | Define the Step 2 canonical proposal promotion boundary | BE | D-01 | 0.2d | raw `candidate_hooks` stay research input only until a canonical proposal passes gating |
 | D-03 | Define Step 2 storage / lineage guardrails | Infra | D-02 | 0.1d | only current persisted lineage surfaces are claimed |
+| D-04 | Define Step 3 result / failure boundaries | Infra | D-03 | 0.1d | factor-derived candidates are judged by existing backtester-owned keep / revert outcomes only |
 
 **Detailed Todo**
 
 - [x] define when factor mining should be invoked
 - [x] define the Step 2 canonical proposal record and promotion gating before candidate generation
-- [ ] define how factors are judged by results
+- [x] define how factors are judged by results
 
 **Dependencies / Risks**
 
@@ -64,25 +67,35 @@
 **Verification Plan**
 
 - sprint4 docs preserve the Step 2 `packet -> canonical proposal -> candidate` boundary
-- docs and focused tests confirm the stated hook/seed gating plus current lineage ceiling
+- sprint4 docs define Step 3 result-judgment semantics through the existing `pending_backtest` / `backtester_outcome_only` contract
+- docs and focused tests confirm skip / defer handling does not redefine the system mission
+- docs do not claim any new hook-level or factor-level persistence beyond the current keep / revert-facing artifacts
 
 **Current Slice Status**
 
-- Sprint 4 Step 2 closeout is complete and verified on `feature/21-optional-factor-mining`; Sprint 4 Step 3 remains open
-- Sprint 4 backend/infra docs now define the optional trigger criteria, the Step 2 canonical proposal record, promotion blocking rules, and the current lineage ceiling for the factor-mining lane
-- Step 2 explicitly keeps factor mining subordinate to the existing autoresearch candidate/backtest path instead of introducing a second candidate lane
+- Sprint 4 Step 2 closeout remains complete and verified on `feature/21-optional-factor-mining`
+- Sprint 4 Step 3 is now complete across both backend and infra docs
+- Sprint 4 now defines promoted factor-derived candidates as normal `pending_backtest` candidates until the existing keep / revert outcome resolves them, and failed factor proposals or candidates are culled through that same keep / revert path instead of a new score
+- Sprint 4 now limits failure handling to skip / defer inside the current mission; it does not redefine the mission, add a parallel authority, or claim any new artifact persistence
+- Sprint 4 now keeps factor mining subordinate to the existing autoresearch candidate -> backtest -> keep / revert path end-to-end and is ready for review handoff
 
 **Verification Evidence**
 
-- `rg -n "canonical proposal|hook_id|seed_type|candidate_hooks|traceability|contrarian_observations|candidate_id|idea_trace|analysis_context|results_tsv|experiment_note" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S` → matched the new Step 2 canonical proposal wording, hook/seed gating, and honest lineage limits
+- `rg -n "canonical proposal|hook_id|seed_type|candidate_hooks|traceability|contrarian_observations|candidate_id|idea_trace|analysis_context|results_tsv|experiment_note" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S` → matched the canonical proposal wording, hook/seed gating, and honest lineage limits
+- `rg -n "pending_backtest|backtester_required|backtester_outcome_only|keep/revert|discard|revert|skip|defer|mission" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S` → matched the Step 3 infra boundary wording that keeps result judgment on the existing keep / revert path and limits failure handling to skip / defer inside the current mission
 - `rg -n "candidate_hooks|traceability|contrarian_observations|hook_id|seed_type|build_candidate_strategy_hypothesis|idea_context\\.path|idea_context\\.source|idea_context\\.title|market_context\\.source|market_context\\.summary|idea_trace|analysis_context|results_tsv|experiment_note" src tests -S` → matched the code-backed field names and current persisted lineage surfaces referenced by the docs
 - `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q` → `11 passed`
+- `uv run python -m compileall src cli.py` → passed
 
 **Acceptance Criteria**
 
 - [x] sprint4 Step 2 docs are execution-ready
 - [x] factor mining remains optional and research-input-only at promotion time
 - [x] Step 2 lineage claims stop at current persisted candidate/backtest artifacts
+- [x] Step 3 result judgment stays inside the existing `pending_backtest` / `backtester_outcome_only` contract
+- [x] weak factor proposals or candidates are eliminated only through the existing keep / revert outcome
+- [x] Step 3 failure handling is limited to skip / defer inside the current mission and does not claim new persistence
+- [x] Sprint 4 issue work is complete and ready for `workflow::review`
 
 **References**
 

--- a/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
@@ -53,7 +53,7 @@
 | Sprint 1 — Autoresearch Core | define core loop + idea intake lane | issue #18 + sprint1 docs | pending | execute sprint1 docs later |
 | Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue #19 + sprint2 docs | pending | execute sprint2 docs later |
 | Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs + packet contract | completed | move issue #20 into review / PR |
-| Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | pending | execute sprint4 docs later |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | in progress | complete Sprint 4 Step 3 result-judgment semantics |
 | Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 
 **Task Table**

--- a/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
@@ -53,7 +53,7 @@
 | Sprint 1 — Autoresearch Core | define core loop + idea intake lane | issue #18 + sprint1 docs | pending | execute sprint1 docs later |
 | Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue #19 + sprint2 docs | pending | execute sprint2 docs later |
 | Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs + packet contract | completed | move issue #20 into review / PR |
-| Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | in progress | complete Sprint 4 Step 3 result-judgment semantics |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | completed | review / merge issue #21 branch |
 | Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 
 **Task Table**

--- a/docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md
+++ b/docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md
@@ -3,7 +3,7 @@
 > Feature: `v2-minute-autoresearch`
 > Role: `Backend`
 > Derived from: `Issue Draft D — Optional Factor-Mining Lane`
-> Last Updated: `2026-04-09`
+> Last Updated: `2026-04-10`
 
 ## 0) Governing Specs
 
@@ -29,12 +29,39 @@
 ## 3) Step-by-Step Plan
 
 ### Step 1 — Define trigger criteria
-- [ ] define when the main loop should invoke factor mining
-- [ ] define what symptoms or needs justify it
+- [x] define when the main loop should invoke factor mining
+- [x] define what symptoms or needs justify it
 
 ### Step 2 — Define candidate integration
-- [ ] define how mined factors become strategy candidates
-- [ ] define how they remain subordinate to the main autoresearch idea loop
+- [x] define how mined factors become strategy candidates
+- [x] define how they remain subordinate to the main autoresearch idea loop
+- [x] define the canonical promotion boundary before candidate generation
+- [x] define the minimum mapping and gating fields required for promotion
+
+Factor mining remains research input only until the minute-level autoresearch loop promotes one selected hook into a
+canonical proposal record. Raw `candidate_hooks` cannot bypass this canonicalization boundary, and factor mining must
+not call `build_candidate_strategy_hypothesis()` directly or create a second candidate lane.
+
+Promotion is blocked unless the selected hook has a non-empty `hook_id`, the seed is explicitly supported, the seed
+payload is non-empty, the proposal note identity is real, and the packet carries explicit non-empty market context.
+
+| Canonical field | Source | Required rule |
+| --- | --- | --- |
+| `idea_context.path` | proposal note path | must be a non-empty real note path; no guessed fallback |
+| `idea_context.source` | proposal note origin | map only to the existing note-origin values `research` or `knowledge`; do not guess new labels |
+| `idea_context.title` | proposal note title | must be a non-empty note title from the promoted proposal |
+| `market_context.source` | canonical proposal record field | copy packet `traceability.analysis_context.source` only when present; otherwise promotion stays blocked until a non-empty value is captured explicitly |
+| `market_context.summary` | canonical proposal record field | copy packet `traceability.analysis_context.summary` only when present; otherwise promotion stays blocked until a non-empty value is captured explicitly |
+
+| Supported `seed_type` | Required payload |
+| --- | --- |
+| `query` | non-empty query string |
+| `topic` | non-empty topic string |
+| `tickers` | non-empty ticker list |
+
+The canonical proposal may then flow through the existing `build_candidate_strategy_hypothesis()` path and carry its
+lineage forward only through the currently real downstream surfaces: `candidate_id`, `idea_trace`,
+`analysis_context.path`, `analysis_context.title`, `artifacts.results_tsv`, and `artifacts.experiment_note`.
 
 ### Step 3 — Define outcome judgment
 - [ ] define that factor quality is only meaningful through improved validated results
@@ -43,30 +70,35 @@
 ## 4) Test Plan
 
 - [ ] verify factor mining is optional
-- [ ] verify factor ideas stay under autoresearch
+- [x] verify factor ideas stay under autoresearch
 - [ ] verify backtester remains the outcome judge
 
 ## 5) Verification Commands
 
 ```bash
-rg -n "factor mining|optional|candidate|results|backtester" docs/feature/v2-minute-autoresearch/sprint4 -S
+rg -n "Step 2|candidate integration|canonical proposal|promotion blocked|raw hooks|hook_id|contrarian_observations|traceability" docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S
 ```
 
 ## 6) Implementation Update Space
 
 ### Completed Work
 
-- leave blank until implemented
+- Defined the Step 2 promotion boundary so factor mining stays research-input-only until the minute autoresearch loop materializes one canonical proposal record from a selected hook.
+- Locked the raw-hook boundary explicitly: raw `candidate_hooks` cannot bypass canonicalization, cannot call `build_candidate_strategy_hypothesis()` directly, and cannot create a second candidate lane.
+- Added a no-guess mapping table for `idea_context.path`, `idea_context.source`, `idea_context.title`, `market_context.source`, and `market_context.summary`, including the existing `research` / `knowledge` note-origin rule.
+- Added supported-seed gating so promotion is blocked unless `hook_id` is non-empty, `seed_type` is one of `query|topic|tickers`, and the corresponding seed payload is non-empty.
+- Made the market-context rule explicit: `market_context.source` and `market_context.summary` are canonical proposal fields that may copy packet `traceability.analysis_context` only when present, otherwise promotion remains blocked.
+- Limited the promoted proposal's downstream lineage claims to current candidate/backtest surfaces only: `candidate_id`, `idea_trace`, `analysis_context.path`, `analysis_context.title`, `artifacts.results_tsv`, and `artifacts.experiment_note`.
 
 ### Command Results
 
-- leave blank until implemented
+- `rg -n "canonical|candidate_hooks|build_candidate_strategy_hypothesis|hook_id|seed_type|idea_context|market_context|candidate_id|idea_trace" docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md -S` → confirms Step 2 now documents the canonical promotion boundary, raw-hook restrictions, required mapping fields, supported seed gating, and bounded lineage surfaces.
+- `rg -n "query|topic|tickers|research|knowledge|results_tsv|experiment_note" docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md -S` → confirms the backend doc records the supported seed types, no-guess source mapping, and current downstream artifact surfaces.
 
 ### Blockers / Deviations
 
-- leave blank until implemented
+- No new backend blockers remain after Step 2.
 
 ### Follow-ups
 
-- leave blank until implemented
-
+- Step 3 should define result-based keep/discard semantics for promoted factor candidates without widening or bypassing the Step 2 canonical promotion contract.

--- a/docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md
+++ b/docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md
@@ -64,19 +64,36 @@ lineage forward only through the currently real downstream surfaces: `candidate_
 `analysis_context.path`, `analysis_context.title`, `artifacts.results_tsv`, and `artifacts.experiment_note`.
 
 ### Step 3 — Define outcome judgment
-- [ ] define that factor quality is only meaningful through improved validated results
-- [ ] define how poor-result factors are discarded
+- [x] define that factor quality is only meaningful through improved validated results
+- [x] define how poor-result factors are discarded
+
+Once a promoted factor hook becomes a candidate, it stays on the existing validation contract: `validation_status`
+remains `pending_backtest` and `validation_rule` remains `backtester_required` until the normal validation flow
+finishes. Factor novelty, rationale quality, or how interesting the mined hook looks cannot upgrade a candidate to
+`keep`, cannot bypass backtesting, and cannot create a second scoring lane.
+
+Keep / revert authority remains the existing keep/revert rule only: `keep_rule=backtester_outcome_only`. A
+factor-derived candidate is judged by the same validated backtester outcomes used for every other candidate, so the
+decision boundary is improved measured results rather than upstream factor quality.
+
+Poor-result factor-derived candidates therefore follow the same existing outcome path as any other weak candidate: once
+validated results fail the keep thresholds, the candidate is discarded / reverted through the normal keep/revert rule.
+Step 3 does not add a new persistence surface, does not add a factor-quality rubric, and does not introduce a separate
+result-judgment lane beyond the current candidate -> backtest -> keep/revert contract.
 
 ## 4) Test Plan
 
-- [ ] verify factor mining is optional
+- [x] verify factor mining is optional
 - [x] verify factor ideas stay under autoresearch
-- [ ] verify backtester remains the outcome judge
+- [x] verify promoted factor-derived candidates stay `pending_backtest` / `backtester_required` until validation completes
+- [x] verify backtester remains the outcome judge
 
 ## 5) Verification Commands
 
 ```bash
 rg -n "Step 2|candidate integration|canonical proposal|promotion blocked|raw hooks|hook_id|contrarian_observations|traceability" docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S
+rg -n "pending_backtest|backtester_required|backtester_outcome_only|discard|revert|scoring lane|persistence surface" docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md src/memory tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -S
+uv run pytest tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q
 ```
 
 ## 6) Implementation Update Space
@@ -89,16 +106,21 @@ rg -n "Step 2|candidate integration|canonical proposal|promotion blocked|raw hoo
 - Added supported-seed gating so promotion is blocked unless `hook_id` is non-empty, `seed_type` is one of `query|topic|tickers`, and the corresponding seed payload is non-empty.
 - Made the market-context rule explicit: `market_context.source` and `market_context.summary` are canonical proposal fields that may copy packet `traceability.analysis_context` only when present, otherwise promotion remains blocked.
 - Limited the promoted proposal's downstream lineage claims to current candidate/backtest surfaces only: `candidate_id`, `idea_trace`, `analysis_context.path`, `analysis_context.title`, `artifacts.results_tsv`, and `artifacts.experiment_note`.
+- Closed Step 3 by documenting that promoted factor-derived candidates remain `pending_backtest` / `backtester_required` until validation completes, so factor novelty or rationale quality never bypasses the existing validation gate.
+- Tied factor-result judgment explicitly to the current keep/revert authority only: `keep_rule=backtester_outcome_only` remains the sole decision rule for factor-derived candidates as well.
+- Recorded that poor-result factor-derived candidates are discarded / reverted through the same existing keep/revert path used for all other candidates, without adding a new persistence surface or a separate factor-scoring lane.
 
 ### Command Results
 
 - `rg -n "canonical|candidate_hooks|build_candidate_strategy_hypothesis|hook_id|seed_type|idea_context|market_context|candidate_id|idea_trace" docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md -S` → confirms Step 2 now documents the canonical promotion boundary, raw-hook restrictions, required mapping fields, supported seed gating, and bounded lineage surfaces.
 - `rg -n "query|topic|tickers|research|knowledge|results_tsv|experiment_note" docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md -S` → confirms the backend doc records the supported seed types, no-guess source mapping, and current downstream artifact surfaces.
+- `rg -n "pending_backtest|backtester_required|backtester_outcome_only|discard|revert|scoring lane|persistence surface" docs/feature/v2-minute-autoresearch/sprint4/sprint4-backend.md src/memory tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -S` → confirms the Step 3 wording matches the existing candidate-generation and keep/revert contract, including `pending_backtest`, `backtester_required`, and `backtester_outcome_only`.
+- `uv run pytest tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q` → verifies the focused contract still passes for pending-backtest candidate generation and backtester-only keep/revert decisions.
 
 ### Blockers / Deviations
 
-- No new backend blockers remain after Step 2.
+- No blocker for backend Step 3 closeout; the wording stays within the existing candidate -> backtest -> keep/revert contract and does not introduce new persistence or scoring behavior.
 
 ### Follow-ups
 
-- Step 3 should define result-based keep/discard semantics for promoted factor candidates without widening or bypassing the Step 2 canonical promotion contract.
+- Keep any later runtime or infra follow-up constrained to execution wiring or artifact reporting; do not let future work reintroduce factor-quality judgment as a parallel authority to backtester outcomes.

--- a/docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md
+++ b/docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md
@@ -35,21 +35,38 @@
 - [x] define the blocking rules for `hook_id`, supported seeds, note provenance, market context, and honest downstream lineage
 
 ### Step 3 — Define failure boundaries
-- [ ] define how factor-mining failure should not stall the main loop unnecessarily
-- [ ] define when the lane should be skipped entirely
+- [x] define how factor-mining failure should not stall the main loop unnecessarily
+- [x] define when the lane should be skipped entirely
+
+Once a factor hook clears Step 2 and becomes a promoted factor-derived candidate, infra treats it as an ordinary
+candidate that remains `pending_backtest` until the existing validation path produces a real outcome. Factor novelty,
+proposal rhetoric, or raw hook quality does not create a second success/failure score.
+
+- If Step 2 gating cannot materialize one canonical proposal record, factor mining is skipped for that loop iteration
+  and the main minute-autoresearch mission continues unchanged.
+- If a promoted factor-derived candidate later produces weak or failed validated results, it is removed through the
+  existing keep/revert outcome used for every other candidate; Step 3 does not add a new factor-specific scoring or
+  review authority.
+- If factor mining is noisy, incomplete, or temporarily unhelpful, the system may defer another attempt to a later
+  loop; this is a local skip/defer decision inside the current mission, not a license to redefine the mission or spin
+  up a parallel decision-maker.
+- Step 3 does not claim any new artifact persistence; the currently documented lineage ceiling remains
+  `candidate_id`, `idea_trace`, `analysis_context.path`, `analysis_context.title`, `artifacts.results_tsv`, and
+  `artifacts.experiment_note`.
 
 ## 4) Test Plan
 
 - [x] verify factor mining remains optional
 - [x] verify canonical proposal promotion gating is explicit
 - [x] verify lineage claims stop at currently persisted keep/revert fields
-- [ ] verify failure does not silently redefine the system mission
+- [x] verify failure does not silently redefine the system mission
 
 ## 5) Verification Commands
 
 ```bash
 rg -n "canonical proposal|hook_id|seed_type|candidate_hooks|traceability|contrarian_observations|candidate_id|idea_trace|analysis_context|results_tsv|experiment_note" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S
 rg -n "candidate_hooks|traceability|contrarian_observations|hook_id|seed_type|build_candidate_strategy_hypothesis|idea_context\\.path|idea_context\\.source|idea_context\\.title|market_context\\.source|market_context\\.summary|idea_trace|analysis_context|results_tsv|experiment_note" src tests -S
+rg -n "pending_backtest|backtester_required|backtester_outcome_only|keep/revert|discard|revert|skip|defer|mission" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S
 uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q
 ```
 
@@ -61,18 +78,27 @@ uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_gen
 - Defined the canonical proposal record to carry `idea_context.path`, `idea_context.source`, `idea_context.title`, exactly one supported seed family from `query|topic|tickers`, proposal-note provenance, `market_context.source`, `market_context.summary`, plus the original `candidate_hooks`, `traceability`, and `contrarian_observations`.
 - Defined Step 2 gating to block promotion when `hook_id` is empty, the selected seed family is unsupported or has an empty payload, proposal note path/title/source is missing, or `market_context.source` / `market_context.summary` cannot be materialized as explicit non-empty canonical proposal fields.
 - Limited lineage claims to currently real downstream surfaces only: `candidate_id`, `idea_trace`, `analysis_context.path`, `analysis_context.title`, `artifacts.results_tsv`, and `artifacts.experiment_note`; raw hook-level keep/revert lineage is not yet persisted and is documented as out of scope for this step.
+- Defined the Step 3 result boundary so promoted factor-derived candidates stay `pending_backtest` until the existing
+  candidate/backtest path yields a validated outcome.
+- Bound poor-result factor proposals and candidates to the same keep/revert elimination rule already used elsewhere;
+  Step 3 rejects new factor-specific scoring, ranking, or manual approval authority.
+- Defined skip/defer behavior for incomplete or low-value factor-mining attempts so the optional lane can be skipped or
+  retried later without redefining the system mission.
+- Kept persistence claims unchanged: Step 3 does not assert any new hook-level, proposal-level, or factor-level
+  artifact storage beyond the currently real keep/revert surfaces.
 
 ### Command Results
 
 - `rg -n "canonical proposal|hook_id|seed_type|candidate_hooks|traceability|contrarian_observations|candidate_id|idea_trace|analysis_context|results_tsv|experiment_note" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S` → confirmed the Step 2 docs now state canonical proposal promotion, hook/seed gating, and the narrowed lineage ceiling.
 - `rg -n "candidate_hooks|traceability|contrarian_observations|hook_id|seed_type|build_candidate_strategy_hypothesis|idea_context\\.path|idea_context\\.source|idea_context\\.title|market_context\\.source|market_context\\.summary|idea_trace|analysis_context|results_tsv|experiment_note" src tests -S` → confirmed the docs match current packet names, candidate-generation inputs, and keep/revert artifact surfaces.
+- `rg -n "pending_backtest|backtester_required|backtester_outcome_only|keep/revert|discard|revert|skip|defer|mission" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S` → confirms Step 3 now documents `pending_backtest`, backtester-owned keep/revert judgment, skip/defer handling, and the no-mission-redefinition rule without claiming new persistence.
 - `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q` → `11 passed`
 
 ### Blockers / Deviations
 
-- No new infra blockers remain after Step 2.
+- No new infra blockers remain after Step 3 doc closeout.
 - Keep/revert storage still does not persist raw `hook_id`, `candidate_hooks`, or `contrarian_observations`; the docs intentionally stop short of claiming that deeper lineage.
 
 ### Follow-ups
 
-- Step 3 should define failure-boundary behavior for rejected or incomplete canonical proposals without broadening into new keep/revert judgment semantics.
+- Issue-level closeout should move the next-step pointer to review / PR once the Step 3 docs and issue card are synchronized.

--- a/docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md
+++ b/docs/feature/v2-minute-autoresearch/sprint4/sprint4-infra.md
@@ -3,7 +3,7 @@
 > Feature: `v2-minute-autoresearch`
 > Role: `Infra`
 > Derived from: `Issue Draft D — Optional Factor-Mining Lane`
-> Last Updated: `2026-04-09`
+> Last Updated: `2026-04-10`
 
 ## 0) Governing Specs
 
@@ -27,12 +27,12 @@
 ## 3) Step-by-Step Plan
 
 ### Step 1 — Define environment assumptions
-- [ ] define what data or compute assumptions factor mining may rely on
-- [ ] define how it degrades when those assumptions are missing
+- [x] define what data or compute assumptions factor mining may rely on
+- [x] define how it degrades when those assumptions are missing
 
-### Step 2 — Define traceability/storage
-- [ ] define how factor proposals are recorded
-- [ ] define how their linkage back to final results is preserved
+### Step 2 — Define canonical proposal traceability/storage
+- [x] define the canonical proposal record required before raw factor hooks can reach candidate generation
+- [x] define the blocking rules for `hook_id`, supported seeds, note provenance, market context, and honest downstream lineage
 
 ### Step 3 — Define failure boundaries
 - [ ] define how factor-mining failure should not stall the main loop unnecessarily
@@ -40,31 +40,39 @@
 
 ## 4) Test Plan
 
-- [ ] verify factor mining remains optional
-- [ ] verify traceability back to results is explicit
+- [x] verify factor mining remains optional
+- [x] verify canonical proposal promotion gating is explicit
+- [x] verify lineage claims stop at currently persisted keep/revert fields
 - [ ] verify failure does not silently redefine the system mission
 
 ## 5) Verification Commands
 
 ```bash
-rg -n "factor|traceability|optional|failure|skip" docs/feature/v2-minute-autoresearch/sprint4 -S
+rg -n "canonical proposal|hook_id|seed_type|candidate_hooks|traceability|contrarian_observations|candidate_id|idea_trace|analysis_context|results_tsv|experiment_note" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S
+rg -n "candidate_hooks|traceability|contrarian_observations|hook_id|seed_type|build_candidate_strategy_hypothesis|idea_context\\.path|idea_context\\.source|idea_context\\.title|market_context\\.source|market_context\\.summary|idea_trace|analysis_context|results_tsv|experiment_note" src tests -S
+uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q
 ```
 
 ## 6) Implementation Update Space
 
 ### Completed Work
 
-- leave blank until implemented
+- Defined the Step 2 promotion boundary as `packet -> canonical proposal -> candidate`: raw `candidate_hooks` remain research input only and cannot bypass canonical proposal materialization before `build_candidate_strategy_hypothesis()`.
+- Defined the canonical proposal record to carry `idea_context.path`, `idea_context.source`, `idea_context.title`, exactly one supported seed family from `query|topic|tickers`, proposal-note provenance, `market_context.source`, `market_context.summary`, plus the original `candidate_hooks`, `traceability`, and `contrarian_observations`.
+- Defined Step 2 gating to block promotion when `hook_id` is empty, the selected seed family is unsupported or has an empty payload, proposal note path/title/source is missing, or `market_context.source` / `market_context.summary` cannot be materialized as explicit non-empty canonical proposal fields.
+- Limited lineage claims to currently real downstream surfaces only: `candidate_id`, `idea_trace`, `analysis_context.path`, `analysis_context.title`, `artifacts.results_tsv`, and `artifacts.experiment_note`; raw hook-level keep/revert lineage is not yet persisted and is documented as out of scope for this step.
 
 ### Command Results
 
-- leave blank until implemented
+- `rg -n "canonical proposal|hook_id|seed_type|candidate_hooks|traceability|contrarian_observations|candidate_id|idea_trace|analysis_context|results_tsv|experiment_note" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md -S` → confirmed the Step 2 docs now state canonical proposal promotion, hook/seed gating, and the narrowed lineage ceiling.
+- `rg -n "candidate_hooks|traceability|contrarian_observations|hook_id|seed_type|build_candidate_strategy_hypothesis|idea_context\\.path|idea_context\\.source|idea_context\\.title|market_context\\.source|market_context\\.summary|idea_trace|analysis_context|results_tsv|experiment_note" src tests -S` → confirmed the docs match current packet names, candidate-generation inputs, and keep/revert artifact surfaces.
+- `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q` → `11 passed`
 
 ### Blockers / Deviations
 
-- leave blank until implemented
+- No new infra blockers remain after Step 2.
+- Keep/revert storage still does not persist raw `hook_id`, `candidate_hooks`, or `contrarian_observations`; the docs intentionally stop short of claiming that deeper lineage.
 
 ### Follow-ups
 
-- leave blank until implemented
-
+- Step 3 should define failure-boundary behavior for rejected or incomplete canonical proposals without broadening into new keep/revert judgment semantics.

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
@@ -64,7 +64,7 @@ Repo note:
 | Sprint 1 — Autoresearch Core | define loop semantics and idea-ingestion lane | issue #18, sprint1 backend/infra docs | pending | execute sprint1 docs later |
 | Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue #19, sprint2 backend/infra docs | pending | execute sprint2 docs later |
 | Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs, discussion packet contract | completed | review / merge issue #20 branch |
-| Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | in progress | complete Sprint 4 Step 3 result-judgment semantics |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | completed | review / merge issue #21 branch |
 | Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 
 ## 7. Task Table

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
@@ -64,7 +64,7 @@ Repo note:
 | Sprint 1 — Autoresearch Core | define loop semantics and idea-ingestion lane | issue #18, sprint1 backend/infra docs | pending | execute sprint1 docs later |
 | Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue #19, sprint2 backend/infra docs | pending | execute sprint2 docs later |
 | Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs, discussion packet contract | completed | review / merge issue #20 branch |
-| Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | pending | execute sprint4 docs later |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | in progress | complete Sprint 4 Step 3 result-judgment semantics |
 | Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
 
 ## 7. Task Table


### PR DESCRIPTION
## Summary
- close out Sprint 4 Step 2 and Step 3 for issue #21 in the canonical sprint4 and umbrella/dev-plan docs
- keep factor-mined candidates on the existing `pending_backtest -> keep/revert` validation path without introducing a second scoring lane
- mark issue #21 as review-ready on the dedicated `feature/21-optional-factor-mining` branch

## Test Plan
- [x] `rg -n "completed|review / merge issue #21 branch|workflow::review|pending_backtest|backtester_outcome_only|skip|defer|mission" docs/feature/v2-minute-autoresearch/sprint4 docs/feature/v2-minute-autoresearch/issue-cards/issue-d-optional-factor-mining.md docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md -S`
- [x] `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q`
- [x] `uv run python -m compileall src cli.py`
- [x] `git diff --check`
