### PR TITLE
docs(issue-17): close out the V2 minute-autoresearch umbrella

### DIFF
--- a/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
@@ -3,7 +3,7 @@
 **Publication Status**
 
 - Published on GitHub as [#17](https://github.com/ricoyudog/Quant-Autoresearch/issues/17)
-- Applied label: `workflow::todo`
+- Closeout target: `workflow::done`
 
 **Feature Branch**
 
@@ -50,11 +50,11 @@
 | Phase | Goal | Deliverables | Status | Next Step |
 | --- | --- | --- | --- | --- |
 | Phase 0 — Spec Alignment | keep one canonical V2 architecture brief | deep-interview spec, branch choice, root choice | completed | preserve this workspace as source of truth |
-| Sprint 1 — Autoresearch Core | define core loop + idea intake lane | issue #18 + sprint1 docs | pending | execute sprint1 docs later |
-| Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue #19 + sprint2 docs | pending | execute sprint2 docs later |
-| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs + packet contract | completed | move issue #20 into review / PR |
-| Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | completed | review / merge issue #21 branch |
-| Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
+| Sprint 1 — Autoresearch Core | define core loop + idea intake lane | issue #18 + sprint1 docs | completed | merged via PRs #23 and #25 |
+| Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue #19 + sprint2 docs | completed | merged via PR #24 |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs + packet contract | completed | merged via PR #26 with post-merge fix PR #27 |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | completed | merged via PR #28 |
+| Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, published issue links | completed | close umbrella issue #17 |
 
 **Task Table**
 
@@ -69,13 +69,13 @@
 
 - [x] publish umbrella and child drafts to GitHub
 - [x] add real issue IDs/URLs back into this umbrella card
-- [ ] use the sprint docs as the execution handoff surface
+- [x] use the sprint docs as the execution handoff surface
 
 **Dependencies / Risks**
 
-- keep local draft and GitHub issue #17 synchronized
-- current implementation may still drift from target V2
-- merge should target `main-dev`, not the stale `feature/v2-research` branch
+- keep local docs and live issue #17 synchronized through final closeout
+- future implementation work should treat `.omx/specs/deep-interview-spec-vs-impl.md` and the merged sprint docs as the governing brief
+- follow-up work should branch from current `main-dev`, not the historical `feature/v2-research` line
 
 **Verification Plan**
 
@@ -89,6 +89,8 @@
 - [x] child issue drafts exist
 - [x] sprint docs exist
 - [x] GitHub publication completed
+- [x] child issue lanes are merged into `main-dev`
+- [x] umbrella merge readiness is fully documented
 
 **References**
 
@@ -102,3 +104,10 @@
 - [#19](https://github.com/ricoyudog/Quant-Autoresearch/issues/19)
 - [#20](https://github.com/ricoyudog/Quant-Autoresearch/issues/20)
 - [#21](https://github.com/ricoyudog/Quant-Autoresearch/issues/21)
+- [PR #22](https://github.com/ricoyudog/Quant-Autoresearch/pull/22)
+- [PR #23](https://github.com/ricoyudog/Quant-Autoresearch/pull/23)
+- [PR #24](https://github.com/ricoyudog/Quant-Autoresearch/pull/24)
+- [PR #25](https://github.com/ricoyudog/Quant-Autoresearch/pull/25)
+- [PR #26](https://github.com/ricoyudog/Quant-Autoresearch/pull/26)
+- [PR #27](https://github.com/ricoyudog/Quant-Autoresearch/pull/27)
+- [PR #28](https://github.com/ricoyudog/Quant-Autoresearch/pull/28)

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
@@ -4,7 +4,7 @@
 > Merge target: `main-dev`
 > Canonical root: `docs/feature/v2-minute-autoresearch/`
 > Source brief: `.omx/specs/deep-interview-spec-vs-impl.md`
-> Planning status: Phase 0 complete; GitHub issue package published; merge handoff targets `main-dev`
+> Planning status: all four child issue lanes merged; umbrella closeout ready
 
 ## 1. Context
 
@@ -31,6 +31,7 @@ Repo note:
 
 - local `main-dev` existed but was fast-forwarded to match `fork/main-dev`
 - GitHub issues were published on 2026-04-09 as `#17` through `#21`
+- child issue delivery completed through merged PRs #23, #24, #25, #26, #27, and #28
 
 ## 3. Scope
 
@@ -61,11 +62,11 @@ Repo note:
 | Phase | Goal | Deliverables | Status | Next Step |
 | --- | --- | --- | --- | --- |
 | Phase 0 — Architecture Alignment | lock canonical V2 shape and workspace root | deep-interview spec, branch decision, workspace root choice | completed | keep this workspace as the single planning root |
-| Sprint 1 — Autoresearch Core | define loop semantics and idea-ingestion lane | issue #18, sprint1 backend/infra docs | pending | execute sprint1 docs later |
-| Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue #19, sprint2 backend/infra docs | pending | execute sprint2 docs later |
-| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs, discussion packet contract | completed | review / merge issue #20 branch |
-| Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | completed | review / merge issue #21 branch |
-| Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, published issue links | in progress | merge planning package into `main-dev` |
+| Sprint 1 — Autoresearch Core | define loop semantics and idea-ingestion lane | issue #18, sprint1 backend/infra docs | completed | merged via PRs #23 and #25 |
+| Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue #19, sprint2 backend/infra docs | completed | merged via PR #24 |
+| Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs, discussion packet contract | completed | merged via PR #26 with post-merge fix PR #27 |
+| Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | completed | merged via PR #28 |
+| Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, published issue links | completed | close umbrella issue #17 |
 
 ## 7. Task Table
 
@@ -88,7 +89,7 @@ Repo note:
 - [x] create `sprint1/` through `sprint4/` execution docs
 - [x] publish the issue-card drafts to GitHub
 - [x] replace provisional issue references with real issue URLs/IDs
-- [ ] merge the planning package into `main-dev`
+- [x] merge the planning package into `main-dev`
 
 ## 9. Dependencies / Risks
 
@@ -117,6 +118,7 @@ Repo note:
 - [x] GitHub issue links are published
 - [x] merge target is documented as `main-dev`
 - [x] real GitHub issue URLs replace draft references
+- [x] all child issue lanes are merged into `main-dev`
 
 ## 12. References
 
@@ -135,4 +137,11 @@ Repo note:
 - [#19](https://github.com/ricoyudog/Quant-Autoresearch/issues/19)
 - [#20](https://github.com/ricoyudog/Quant-Autoresearch/issues/20)
 - [#21](https://github.com/ricoyudog/Quant-Autoresearch/issues/21)
+- [PR #22](https://github.com/ricoyudog/Quant-Autoresearch/pull/22)
+- [PR #23](https://github.com/ricoyudog/Quant-Autoresearch/pull/23)
+- [PR #24](https://github.com/ricoyudog/Quant-Autoresearch/pull/24)
+- [PR #25](https://github.com/ricoyudog/Quant-Autoresearch/pull/25)
+- [PR #26](https://github.com/ricoyudog/Quant-Autoresearch/pull/26)
+- [PR #27](https://github.com/ricoyudog/Quant-Autoresearch/pull/27)
+- [PR #28](https://github.com/ricoyudog/Quant-Autoresearch/pull/28)
 - `.omx/specs/deep-interview-spec-vs-impl.md`

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md
@@ -6,12 +6,12 @@ Ensure the planning package can be reviewed and merged into `main-dev` without h
 
 ## Merge Checks
 
-- [ ] branch is `feature/v2-minute-autoresearch`
-- [ ] base/target is documented as `main-dev`
-- [ ] only one canonical feature root exists
-- [ ] issue drafts point to sprint docs
-- [ ] sprint docs point back to governing specs and issue drafts
-- [ ] GitHub issue links are explicit and honest
+- [x] branch is `feature/v2-minute-autoresearch`
+- [x] base/target is documented as `main-dev`
+- [x] only one canonical feature root exists
+- [x] issue drafts point to sprint docs
+- [x] sprint docs point back to governing specs and issue drafts
+- [x] GitHub issue links are explicit and honest
 
 ## Commands
 
@@ -25,9 +25,14 @@ find docs/feature/v2-minute-autoresearch -maxdepth 3 -type f | sort
 
 ### Merge Readiness Notes
 
-- leave blank until closeout
+- `git branch --show-current` → `feature/v2-minute-autoresearch`
+- `git diff --name-only main-dev..HEAD` → umbrella-closeout doc sync only on this branch
+- `find docs/feature/v2-minute-autoresearch -maxdepth 3 -type f | sort` → one canonical feature root with issue cards plus sprint1-4 execution docs
+- planning workspace landed on `main-dev` via [PR #22](https://github.com/ricoyudog/Quant-Autoresearch/pull/22) on 2026-04-09
+- child lanes landed via [PR #23](https://github.com/ricoyudog/Quant-Autoresearch/pull/23), [PR #24](https://github.com/ricoyudog/Quant-Autoresearch/pull/24), [PR #25](https://github.com/ricoyudog/Quant-Autoresearch/pull/25), [PR #26](https://github.com/ricoyudog/Quant-Autoresearch/pull/26), [PR #27](https://github.com/ricoyudog/Quant-Autoresearch/pull/27), and [PR #28](https://github.com/ricoyudog/Quant-Autoresearch/pull/28)
+- issue #17 is the final umbrella closeout card; all child issues #18-#21 are already merged / done
 
 ### Publication Follow-up
 
-- keep local issue-card drafts aligned with GitHub issues
-- merge this docs package into `main-dev`
+- keep the umbrella issue body aligned with the merged local docs through closeout
+- move live issue #17 from `workflow::todo` to `workflow::done` once this umbrella sync merges


### PR DESCRIPTION
## Summary
- sync umbrella issue #17 docs to the merged state after child lanes #18-#21 landed on `main-dev`
- mark Phase 5 merge readiness complete in the umbrella card, development plan, and merge-test ledger
- record the full merged PR lineage (#22-#28) and final board target for umbrella closeout

## Test Plan
- [x] `rg -n "workflow::done|PR #28|close umbrella issue #17|merged via PR|all child issue lanes are merged|umbrella issue #17 is the final umbrella closeout card" docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md -S`
- [x] `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q`
- [x] `uv run python -m compileall src cli.py`
- [x] `git diff --check`
