### PR TITLE
docs: keep V2 closeout records accurate on main-dev

### DIFF
--- a/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
+++ b/docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
@@ -3,7 +3,7 @@
 **Publication Status**
 
 - Published on GitHub as [#17](https://github.com/ricoyudog/Quant-Autoresearch/issues/17)
-- Closeout target: `workflow::done`
+- Current state: closed on GitHub with `workflow::done`
 
 **Feature Branch**
 
@@ -54,7 +54,7 @@
 | Sprint 2 — Minute Runtime | define minute-level runtime and validation lane | issue #19 + sprint2 docs | completed | merged via PR #24 |
 | Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion lane | issue #20 + sprint3 docs + packet contract | completed | merged via PR #26 with post-merge fix PR #27 |
 | Sprint 4 — Factor Mining Lane | define optional factor-mining lane | issue #21 + sprint4 docs | completed | merged via PR #28 |
-| Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, published issue links | completed | close umbrella issue #17 |
+| Phase 5 — Verification / Merge | verify docs + merge readiness | test docs, merge-test plan, published issue links | completed | historical closeout record only |
 
 **Task Table**
 
@@ -73,7 +73,7 @@
 
 **Dependencies / Risks**
 
-- keep local docs and live issue #17 synchronized through final closeout
+- avoid post-closeout drift between this card and the merged local docs if later historical edits are needed
 - future implementation work should treat `.omx/specs/deep-interview-spec-vs-impl.md` and the merged sprint docs as the governing brief
 - follow-up work should branch from current `main-dev`, not the historical `feature/v2-research` line
 

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md
@@ -4,7 +4,7 @@
 > Merge target: `main-dev`
 > Canonical root: `docs/feature/v2-minute-autoresearch/`
 > Source brief: `.omx/specs/deep-interview-spec-vs-impl.md`
-> Planning status: all four child issue lanes merged; umbrella closeout ready
+> Planning status: all four child issue lanes merged; umbrella closeout completed
 
 ## 1. Context
 
@@ -66,7 +66,7 @@ Repo note:
 | Sprint 2 — Minute Runtime | align runtime/data/validation to the minute-level mission | issue #19, sprint2 backend/infra docs | completed | merged via PR #24 |
 | Sprint 3 — Stock Discussion Lane | define strategy-facing stock discussion under autoresearch | issue #20, sprint3 backend/infra docs, discussion packet contract | completed | merged via PR #26 with post-merge fix PR #27 |
 | Sprint 4 — Factor Mining Lane | define optional factor-mining sub-mode | issue #21, sprint4 backend/infra docs | completed | merged via PR #28 |
-| Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, published issue links | completed | close umbrella issue #17 |
+| Phase 5 — Verification + Merge | verify docs coherence and merge-readiness for `main-dev` | test plan, merge-test plan, published issue links | completed | historical closeout record only |
 
 ## 7. Task Table
 

--- a/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md
+++ b/docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md
@@ -2,22 +2,25 @@
 
 ## Goal
 
-Ensure the planning package can be reviewed and merged into `main-dev` without hidden root drift or missing execution handoff.
+Ensure the merged planning package still reads truthfully on `main-dev` without hidden root drift or missing execution handoff.
 
 ## Merge Checks
 
-- [x] branch is `feature/v2-minute-autoresearch`
+- [x] `main-dev` contains the umbrella-closeout commit
 - [x] base/target is documented as `main-dev`
 - [x] only one canonical feature root exists
 - [x] issue drafts point to sprint docs
 - [x] sprint docs point back to governing specs and issue drafts
-- [x] GitHub issue links are explicit and honest
+- [x] GitHub issue links and closeout state are explicit and honest
 
 ## Commands
 
 ```bash
-git branch --show-current
-git diff --name-only main-dev..HEAD
+git branch --contains HEAD
+rg -n "workflow::done|closed on GitHub|historical closeout record only" \
+  docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-development-plan.md \
+  docs/feature/v2-minute-autoresearch/v2-minute-autoresearch-merge-test-plan.md \
+  docs/feature/v2-minute-autoresearch/issue-cards/umbrella-v2-minute-autoresearch.md
 find docs/feature/v2-minute-autoresearch -maxdepth 3 -type f | sort
 ```
 
@@ -25,14 +28,14 @@ find docs/feature/v2-minute-autoresearch -maxdepth 3 -type f | sort
 
 ### Merge Readiness Notes
 
-- `git branch --show-current` → `feature/v2-minute-autoresearch`
-- `git diff --name-only main-dev..HEAD` → umbrella-closeout doc sync only on this branch
+- `git branch --contains HEAD` → `main-dev` contains the umbrella-closeout commit on the merged line
+- `rg -n "workflow::done|closed on GitHub|historical closeout record only" ...` → development plan, merge-test ledger, and umbrella issue card all record issue #17 as already closed/done
 - `find docs/feature/v2-minute-autoresearch -maxdepth 3 -type f | sort` → one canonical feature root with issue cards plus sprint1-4 execution docs
 - planning workspace landed on `main-dev` via [PR #22](https://github.com/ricoyudog/Quant-Autoresearch/pull/22) on 2026-04-09
 - child lanes landed via [PR #23](https://github.com/ricoyudog/Quant-Autoresearch/pull/23), [PR #24](https://github.com/ricoyudog/Quant-Autoresearch/pull/24), [PR #25](https://github.com/ricoyudog/Quant-Autoresearch/pull/25), [PR #26](https://github.com/ricoyudog/Quant-Autoresearch/pull/26), [PR #27](https://github.com/ricoyudog/Quant-Autoresearch/pull/27), and [PR #28](https://github.com/ricoyudog/Quant-Autoresearch/pull/28)
-- issue #17 is the final umbrella closeout card; all child issues #18-#21 are already merged / done
+- issue #17 is the final umbrella closeout card and is already closed on GitHub with `workflow::done`; all child issues #18-#21 are already merged / done
 
 ### Publication Follow-up
 
-- keep the umbrella issue body aligned with the merged local docs through closeout
-- move live issue #17 from `workflow::todo` to `workflow::done` once this umbrella sync merges
+- keep the umbrella issue card aligned with the merged local docs if future historical edits are needed
+- branch any follow-up work from current `main-dev`; do not reopen this closeout ledger unless the live issue state changes


### PR DESCRIPTION
## Summary
- make the V2 merge-test ledger true after merge on `main-dev`
- mark Phase 5 and the umbrella closeout docs as historical/closed rather than pending
- keep the canonical V2 closeout docs aligned with the live `workflow::done` board state

## Test Plan
- [x] `uv run pytest tests/unit/test_discussion_packet.py tests/unit/test_candidate_generation.py tests/unit/test_idea_keep_revert.py -q`
- [x] `uv run python -m compileall src cli.py`
- [x] `git diff --check`
