### PR TITLE
feat: add read-only research dashboard

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -42,6 +42,7 @@ from core.research import (
     search_web,
 )
 from data.cache_connector import CacheConnector
+from dashboard.server import serve_dashboard
 from memory.experiment_memory import CONTINUATION_MANIFEST_PATH, refresh_research_base
 
 app = typer.Typer(help="Quant Autoresearch")
@@ -493,6 +494,32 @@ def analyze(
 
     if output_path is not None:
         typer.echo(f"Wrote analysis note: {output_path}")
+
+
+@app.command()
+def dashboard(
+    host: str = typer.Option("127.0.0.1", "--host", help="Host interface for the local dashboard."),
+    port: int = typer.Option(8765, "--port", help="Port for the local dashboard."),
+    repo_root: Path = typer.Option(Path("."), "--repo-root", help="Repository root to observe."),
+    refresh_seconds: float = typer.Option(3.0, "--refresh-seconds", help="Browser polling interval in seconds."),
+):
+    """Serve the read-only local research dashboard."""
+    if refresh_seconds <= 0:
+        typer.echo("--refresh-seconds must be greater than 0.")
+        raise typer.Exit(code=1)
+
+    resolved_root = repo_root.expanduser().resolve()
+    typer.echo(f"Dashboard listening on http://{host}:{port}")
+    typer.echo(f"Observing repository: {resolved_root}")
+    try:
+        serve_dashboard(
+            repo_root=resolved_root,
+            host=host,
+            port=port,
+            refresh_seconds=refresh_seconds,
+        )
+    except KeyboardInterrupt:
+        typer.echo("Dashboard stopped.")
 
 
 @app.command()

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/.github.yaml
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/.github.yaml
@@ -1,0 +1,24 @@
+parent:
+  number: 31
+  url: https://github.com/ricoyudog/Quant-Autoresearch/issues/31
+groups:
+  - number: 1
+    name: "Observer Foundation"
+    issue_number: 32
+    url: https://github.com/ricoyudog/Quant-Autoresearch/issues/32
+  - number: 2
+    name: "Home Page Live Monitor"
+    issue_number: 33
+    url: https://github.com/ricoyudog/Quant-Autoresearch/issues/33
+  - number: 3
+    name: "Iteration Analysis Views"
+    issue_number: 34
+    url: https://github.com/ricoyudog/Quant-Autoresearch/issues/34
+  - number: 4
+    name: "Health Diagnostics and Failure UX"
+    issue_number: 35
+    url: https://github.com/ricoyudog/Quant-Autoresearch/issues/35
+  - number: 5
+    name: "Verification and Finish"
+    issue_number: 36
+    url: https://github.com/ricoyudog/Quant-Autoresearch/issues/36

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/.worktree.yaml
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/.worktree.yaml
@@ -1,0 +1,3 @@
+path: .worktrees/stargatey-research-dashboard
+branch: feat/stargatey-research-dashboard
+created: 2026-04-19T15:34:48Z

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/design.md
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/design.md
@@ -1,0 +1,123 @@
+## Context
+
+Quant Autoresearch already emits the right raw ingredients for a live dashboard:
+
+- `experiments/autoresearch_state.json` for run state
+- `experiments/iterations/<run_id>/iteration-<n>/` for structured iteration artifacts and logs
+- `experiments/results.tsv` for a stable performance ledger
+- retained snapshots and strategy files for diffing
+
+The current operator workflow is manual. To answer whether a run is healthy, the operator has to inspect multiple files and infer whether silence means completion, waiting, or a fault. To understand whether research is improving, the operator has to correlate artifacts, logs, snapshots, and ledger rows.
+
+The dashboard must fit the repo’s current architecture:
+
+- it must stay local-first
+- it must not replace CLI execution
+- it must not imply unsupported autonomous promotion behavior
+- it must preserve evaluator/backtester-led keep/revert authority
+
+The operator preference is a dense, solo-use cockpit with a timeline-first structure and quant-monitor support panels, prioritizing risk-adjusted quality over raw score.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a local web dashboard that answers run health within 10 seconds.
+- Normalize repo-local state, logs, artifacts, and ledger data into a stable dashboard model.
+- Make iteration evolution the primary narrative via a timeline-first UI.
+- Support drill-down analysis for a selected iteration, including hypothesis diff, strategy diff, metrics, and decision reasoning.
+- Detect and explain stalled, blocked, failed, and waiting states without changing the underlying runtime contract.
+- Keep the design additive and reversible.
+
+**Non-Goals:**
+- Starting, pausing, stopping, or editing research from the dashboard.
+- Replacing CLI commands or the backtester’s authority.
+- Building a collaboration or multi-user system.
+- Shipping a full multi-run history center in the first version.
+- Defining a specific frontend framework or chart library in this proposal stage.
+
+## Decisions
+
+### 1. Use a local read-only dashboard service
+
+**Decision:** Implement the dashboard as a local web application backed by a read-only observer/service layer.
+
+**Why:** The operator needs drill-down pages, timeline navigation, diff views, and charts that are awkward in a TUI. A local web surface supports dense information without changing the execution path.
+
+**Alternatives considered:**
+- Terminal dashboard only: lower build complexity, but weaker for timeline navigation, diffs, and side-by-side comparison.
+- Static report generation: simpler delivery, but insufficient for live heartbeat and run-health monitoring.
+
+### 2. Introduce a normalized observer model between files and UI
+
+**Decision:** Add a backend observer layer that reads raw repo files and emits normalized run, iteration, metric, and health state for the UI.
+
+**Why:** The raw files arrive at different times and have different roles. The UI should not encode direct file-specific logic for every view. A normalized model makes testing, stale-state detection, and partial updates much easier.
+
+**Alternatives considered:**
+- Read files directly in the UI: fast to start, but couples the UI to file timing and repo structure.
+- Only render `results.tsv`: stable, but loses live heartbeat and decision context.
+
+**Data model impact:** The implementation will need normalized entities such as `RunSummary`, `RunHealth`, `IterationSummary`, `IterationDetail`, `MetricComparison`, and `ArtifactStatus`.
+
+### 3. Make run health topmost and timeline primary
+
+**Decision:** The home page should use `Run Health Strip` first, `Iteration Timeline` as primary navigation, `Selected Iteration Panel` as the main detail region, and dense support panels as secondary awareness aids.
+
+**Why:** The operator’s top question is whether the run is healthy. The second need is understanding how the research direction changes across rounds. This makes a timeline-first shell more useful than a generic panel grid.
+
+**Alternatives considered:**
+- Grid-first quant monitor: dense, but weak for storytelling and stepwise evolution.
+- Latest-round-only focus: fast to read, but hides direction drift and iteration learning.
+
+### 4. Prioritize logs, then artifacts, then results ledger
+
+**Decision:** The observer should treat logs as the fastest heartbeat, structured artifacts as the source of meaning, and `results.tsv` as the ledger confirmation layer.
+
+**Why:** These surfaces land at different times during a live run. The dashboard must be able to show activity before a full decision record exists, then enrich the view as the structured files appear, and finally confirm metrics once the ledger updates.
+
+**Alternatives considered:**
+- State file only: too coarse for run liveness and phase inference.
+- Ledger-first: too slow for live monitoring.
+
+### 5. Normalize health and iteration status explicitly
+
+**Decision:** The observer must map raw repo state into a finite run-status model (`Healthy`, `Busy`, `Waiting`, `Stalled`, `Failed`, `Blocked`, `Completed`) and iteration-status model (`Queued`, `In Progress`, `Decision Pending`, `Evaluated`, `Kept`, `Reverted`, `Follow-up`, `Failed`).
+
+**Why:** Operators need a consistent interpretation layer instead of inferring semantics from raw files and timestamps.
+
+**Alternatives considered:**
+- Expose raw state fields directly: less code, but shifts interpretation burden back to the operator.
+
+**API contract impact:** The implementation should expose one dashboard-facing contract that includes explicit status enums, timestamps, diagnosis signals, and comparison data rather than raw file blobs.
+
+### 6. Keep first-version scope additive and rollback-safe
+
+**Decision:** The first version will only add read-only monitoring and analysis surfaces.
+
+**Why:** The repo already has a working CLI-led research contract. A read-only dashboard can be introduced without changing the strategy loop’s authority or needing migration of existing artifacts.
+
+**Alternatives considered:**
+- Adding dashboard controls in v1: attractive, but increases risk and blurs runtime boundaries too early.
+
+## Risks / Trade-offs
+
+- [Partial artifact timing] → The dashboard may see logs before `decision.json` or `iteration_record.json` exists. Mitigation: model incomplete states explicitly and fill details progressively.
+- [Status misclassification] → Silence can mean waiting, stall, or completion. Mitigation: base health on multiple signals (`updated_at`, log freshness, presence of decision artifacts, stop reason).
+- [Framework choice drift] → Picking a heavy stack could slow delivery. Mitigation: keep the design framework-agnostic until implementation planning chooses the smallest viable stack.
+- [Diff complexity] → Strategy and hypothesis diffs can be noisy. Mitigation: separate conceptual diff from code diff and default to concise summaries with expandable detail.
+- [Live polling cost] → Aggressive refresh loops can add noise or overhead. Mitigation: keep the update model small and prioritize health-strip updates over full view recomputation.
+
+## Migration Plan
+
+1. Implement the observer layer against existing repo-local artifacts and state files.
+2. Add the home page shell with run health, timeline, and selected-iteration panel.
+3. Add the iteration detail page and diff/metric comparison views.
+4. Validate against real and simulated run states, including stale and failed conditions.
+5. Roll back by disabling or removing the dashboard service and routes if needed; no artifact migration is required because the dashboard is read-only and additive.
+
+## Open Questions
+
+- Which local web/runtime stack best fits the repo without adding unnecessary dependencies?
+- Should the first implementation use filesystem watching, short-interval polling, or a hybrid?
+- How much strategy diff context should be rendered inline before falling back to linked detail?
+- Should the first version expose note-draft content inline or only summarize it in the decision section?

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/implementation-notes.md
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/implementation-notes.md
@@ -1,0 +1,138 @@
+## Group 1: Observer Foundation
+
+### Local dashboard runtime
+
+Chosen stack: Python stdlib `http.server.ThreadingHTTPServer` with a read-only
+`BaseHTTPRequestHandler`, vanilla HTML/CSS/JavaScript static assets, and short
+browser polling against a JSON endpoint backed by `src.dashboard.observer`.
+
+Rationale:
+
+- No new dependencies are required.
+- The existing repo already exposes Typer CLI commands, so a future
+  `dashboard` command can launch the stdlib server without changing the
+  research-loop execution surface.
+- Polling every 2–5 seconds is enough for the first local cockpit because the
+  dashboard only reads artifact files and never controls the runner.
+- The observer stays independent from the UI so status normalization, stale
+  detection, and artifact parsing are unit-testable without starting a server.
+
+Rejected for the first version:
+
+- FastAPI/Flask/Streamlit: faster web scaffolding, but each adds a runtime
+  dependency that is not needed for read-only local polling.
+- WebSockets or filesystem watchers: useful later, but polling is simpler and
+  adequate for the local single-operator dashboard.
+
+### Observer contract
+
+`observe_dashboard_state(repo_root, now=None, stale_after_seconds=600)` reads:
+
+- `experiments/autoresearch_state.json`
+- `experiments/iterations/<run_id>/iteration-*/` records, decisions, and logs
+- `experiments/results.tsv`
+
+It emits normalized run status, heartbeat diagnostics, iteration summaries,
+artifact availability, ledger rows, and source existence metadata for future UI
+routes.
+
+### Operator launch and status guide
+
+Launch the read-only dashboard from the repository root:
+
+```bash
+uv run python cli.py dashboard
+```
+
+Useful options:
+
+- `--repo-root <path>`: point the dashboard at a different repository root.
+- `--host 127.0.0.1` and `--port 8765`: change the local bind address.
+- `--refresh-seconds 3.0`: adjust browser polling frequency.
+
+The dashboard is read-only and only observes local artifacts; it does not start,
+pause, or modify research runs.
+
+#### Run status labels
+
+- `Healthy`: the run is running with a fresh heartbeat and no active iteration claim.
+- `Busy`: the state file names an active iteration.
+- `Waiting`: no active run state exists yet, or the run has no active iteration and no fresh heartbeat.
+- `Stalled`: the latest heartbeat is older than the stale threshold (default 600 seconds).
+- `Blocked`: the run state says `blocked`.
+- `Failed`: the run state says `failed`.
+- `Completed`: the run state says `completed`.
+
+#### Iteration status labels
+
+- `Queued`: the iteration has not produced logs or decision artifacts yet.
+- `In Progress`: logs exist and the iteration is still missing final artifacts.
+- `Decision Pending`: the iteration is complete enough to evaluate, but no final decision artifact is present yet.
+- `Evaluated`: the iteration has a record, but no final keep/revert decision is attached.
+- `Kept`: the final decision is keep.
+- `Reverted`: the final decision is revert.
+- `Follow-up`: the final decision requests a follow-up.
+- `Failed`: the iteration or artifact flow failed.
+
+#### Diagnosis messaging
+
+The dashboard prints diagnosis text as `reason`, then detail lines, then any
+heartbeat age or missing-artifact markers.
+
+- Run-level diagnosis:
+  - `awaiting_state` means the state file is missing.
+  - `awaiting_activity` means the state file exists but no active iteration or fresh heartbeat is present.
+  - `heartbeat_stale` means the run is stalled; the dashboard also shows the affected iteration, heartbeat age, stale signal, and source path.
+  - blocked or failed runs surface `stop_reason`, `last_error`, or the raw status as the reason, plus any split decision details.
+  - completed runs surface `stop_reason`, plus `last_completed_iteration=<n>` when available.
+- Iteration-level diagnosis:
+  - `failed_iteration` surfaces recorded failure reasons or error text.
+  - `decision_pending` means the dashboard is waiting on a final decision artifact.
+  - `artifacts_pending` means the iteration is still active and missing final artifacts.
+  - `queued` means the iteration has not produced logs or decision artifacts yet.
+  - `decision_recorded` means the decision reasons are available and are shown directly.
+
+### Group 5 validation evidence
+
+Verification used a representative dashboard fixture rooted at
+`experiments/iterations/` with two completed iterations, ledger rows, logs, and
+state metadata.
+
+- The representative fixture now derives its timestamps from test execution
+  time, so the home-page expectation stays `Healthy` instead of aging into
+  `Stalled` during later reruns.
+- `uv run pytest tests/integration/test_dashboard_validation.py -q` validates the
+  representative artifact tree via the HTTP handler and confirms `/`,
+  `/api/state`, and `/iterations/2` respond within 10 seconds.
+- `uv run pytest -q` keeps the full repository suite green after the dashboard
+  verification harness was added.
+- Browser validation used Playwright against a temporary repo root fixture:
+  the home page and iteration-detail page both rendered in 2 seconds, the home
+  page showed `Healthy` / `run-verify`, and the detail page showed the expected
+  hypothesis diff, strategy diff, metric breakdown, and recorded decision
+  reasons.
+
+### Group 5 hardening review evidence
+
+Additional pre-archive code review found dashboard hardening gaps around
+untrusted browser rendering, repo-relative artifact paths, ambiguous ledger
+correlation, stale fallback run selection, and heartbeat freshness.
+
+- Dashboard JavaScript now escapes values before using `innerHTML` for health,
+  timeline, recent activity, artifact references, and log excerpts.
+- Artifact references resolve repo-relative paths against the observed
+  repository root.
+- Ledger-backed metrics are only attached when the ledger row has an explicit,
+  unambiguous iteration identifier; ambiguous append-only ledger rows remain
+  visible in the ledger panel but are not assigned to a specific iteration.
+- The observer does not fall back to old run directories when no active state
+  file exists.
+- Heartbeat selection considers the freshest viable signal across logs,
+  artifacts, and state rather than letting any old log dominate liveness.
+- Browser smoke validation with malicious log and artifact text rendered the
+  strings visibly as text while keeping the dashboard usable.
+- The final follow-up removed the last unkeyed single-row ledger fallback and
+  resets selected/detail panels when refreshed dashboard state no longer has
+  matching iterations.
+- Final verification: focused dashboard tests passed, full `uv run pytest -q`
+  passed with 355 tests, and Python compile/diff checks passed.

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/proposal.md
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Quant Autoresearch currently exposes the research loop through CLI commands, raw logs, iteration artifact folders, and `experiments/results.tsv`, but it does not provide a single live cockpit that shows whether the current run is healthy and how the research direction is evolving. We need a local dashboard now so the operator can understand the active run within seconds instead of stitching together state, logs, artifacts, and metrics by hand.
+
+## What Changes
+
+- Add a local web dashboard for the active research run that is read-only and keeps CLI as the execution surface.
+- Add a live run-health view that summarizes status, heartbeat freshness, active iteration, and blocked/stalled/failed conditions.
+- Add an iteration timeline that shows hypothesis-direction evolution alongside risk-adjusted metrics for each round.
+- Add a selected-iteration panel and detail view that explain hypothesis changes, strategy diffs, metric breakdowns, and keep/revert/follow-up reasoning.
+- Add a normalized observer layer that reads repo-local run state, iteration artifacts, logs, and `experiments/results.tsv` into a stable dashboard model.
+- Preserve future expansion for multi-run history without making it a first-version requirement.
+
+## Capabilities
+
+### New Capabilities
+- `research-dashboard-monitoring`: Live monitoring surface for active run health, iteration timeline, and high-signal quant panels.
+- `research-dashboard-iteration-analysis`: Iteration-focused analysis views for hypothesis diff, strategy diff, metrics, and decision reasoning.
+- `research-dashboard-observer`: Local observer model that ingests run state, logs, artifacts, and ledger data into normalized dashboard state.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected systems: local dashboard runtime, dashboard UI routes/views, observer/service layer, repo-local artifact readers.
+- Affected data surfaces: `experiments/autoresearch_state.json`, `experiments/iterations/**`, `experiments/results.tsv`, strategy snapshots, and generated note drafts.
+- API impact: introduces a new local dashboard-facing state contract for run health, timeline nodes, iteration details, and normalized statuses.
+- Dependency impact: no new dependency is required by the proposal itself, but implementation will need to choose a lightweight local web/UI stack.
+- Runtime impact: additive only; CLI start/stop behavior and evaluator-led keep/revert authority remain unchanged.
+
+## GitHub Issue
+
+- Parent: #2 (https://github.com/yllvar/Quant-Autoresearch/issues/2)

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/specs/research-dashboard-iteration-analysis/spec.md
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/specs/research-dashboard-iteration-analysis/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Dashboard explains the selected iteration in a fixed reading order
+The system SHALL render the selected iteration using a stable reading order that prioritizes research intent before quantitative evidence and decision outcome.
+
+#### Scenario: Selected iteration panel uses the approved section order
+- **WHEN** an operator selects an iteration from the timeline
+- **THEN** the dashboard shows `Hypothesis diff`, `Strategy diff`, `Metric breakdown`, and `Decision reasoning` in that order
+
+### Requirement: Dashboard provides drill-down detail for a single iteration
+The system SHALL provide a dedicated iteration detail view for deep inspection of one iteration.
+
+#### Scenario: Iteration detail page expands inspection depth
+- **WHEN** the operator opens an iteration detail view
+- **THEN** the page shows the iteration’s normalized status, hypothesis summary, strategy diff, metric breakdown, decision reasoning, and key artifact or log references for that iteration
+
+### Requirement: Dashboard compares each iteration against approved baselines
+The system SHALL support comparison of the selected iteration against the previous iteration, the current baseline, and the best iteration in the active run.
+
+#### Scenario: Metrics expose the three required comparison baselines
+- **WHEN** the dashboard renders metric details for a selected iteration
+- **THEN** it presents comparisons for `vs previous iteration`, `vs current baseline`, and `vs best iteration in current run`
+
+#### Scenario: Conceptual and code changes can be inspected together
+- **WHEN** an iteration has both hypothesis context and strategy changes
+- **THEN** the operator can inspect the hypothesis/decision diff and the strategy diff from the same iteration view without leaving the dashboard flow
+
+### Requirement: Dashboard distinguishes decision outcomes with reasons
+The system SHALL distinguish kept, reverted, follow-up, and failed iterations and explain why the outcome was assigned.
+
+#### Scenario: Decision reasoning is visible for a completed iteration
+- **WHEN** an iteration has a completed decision artifact
+- **THEN** the dashboard shows the normalized decision outcome and the recorded reasons for that outcome in the selected-iteration view and detail page

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/specs/research-dashboard-monitoring/spec.md
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/specs/research-dashboard-monitoring/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Dashboard shows active run health first
+The system SHALL provide a home page that surfaces the active run’s health before any secondary dashboard content.
+
+#### Scenario: Healthy run summary is visible on page load
+- **WHEN** the operator opens the dashboard while an active run has fresh state or log activity
+- **THEN** the dashboard shows the run identifier, normalized status, active iteration, latest update time, and heartbeat freshness in a dedicated top-level run-health region
+
+#### Scenario: Blocked or failed run is summarized clearly
+- **WHEN** the observer detects a blocked, failed, or completed run state
+- **THEN** the run-health region shows the normalized status and the associated stop or failure reason without requiring the operator to inspect raw files
+
+### Requirement: Dashboard presents a timeline of active-run iterations
+The system SHALL present the active run as a timeline of iterations that emphasizes research-direction evolution and risk-adjusted change over time.
+
+#### Scenario: Latest iteration is selected by default
+- **WHEN** the dashboard loads an active run with one or more completed or in-progress iterations
+- **THEN** the latest iteration is selected automatically and highlighted in the timeline
+
+#### Scenario: Timeline nodes summarize key iteration signals
+- **WHEN** an iteration has enough structured data to render a timeline node
+- **THEN** the node shows the iteration number, a short hypothesis or direction label, `drawdown`, `turnover`, `deflated_sr`, and `baseline delta`
+
+### Requirement: Dashboard exposes dense support panels for live awareness
+The system SHALL provide secondary quant-monitor panels that increase live situational awareness without replacing the timeline as primary navigation.
+
+#### Scenario: Support panels show recent activity and trend context
+- **WHEN** the home page renders an active run
+- **THEN** the dashboard shows recent log activity, artifact availability, run-level performance trend, and recent decision summary in support panels adjacent to the main timeline and selected-iteration views
+
+#### Scenario: Support panels update as new iteration data lands
+- **WHEN** new log lines, artifacts, or ledger updates appear for the active run
+- **THEN** the related support panels refresh to reflect the latest available information without requiring a full page reload

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/specs/research-dashboard-observer/spec.md
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/specs/research-dashboard-observer/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Observer ingests repo-local run and iteration sources
+The system SHALL ingest the current run state, per-iteration artifacts, per-iteration logs, and results ledger data from the local repository.
+
+#### Scenario: Observer reads all required source classes
+- **WHEN** the dashboard backend refreshes the active run
+- **THEN** it reads `experiments/autoresearch_state.json`, relevant files under `experiments/iterations/<run_id>/`, and `experiments/results.tsv` to build dashboard state
+
+### Requirement: Observer prioritizes source freshness by role
+The system SHALL treat logs as the primary heartbeat source, structured artifacts as the primary semantic source, and the results ledger as the confirmation source for landed metrics.
+
+#### Scenario: Heartbeat appears before ledger confirmation
+- **WHEN** new log output exists for an active iteration but no new ledger row has been written yet
+- **THEN** the dashboard still marks the run as active based on log freshness while deferring ledger-confirmed metric state until results data arrives
+
+#### Scenario: Structured meaning appears after raw activity
+- **WHEN** `decision.json` or `iteration_record.json` is written after earlier log activity
+- **THEN** the observer enriches the affected iteration with hypothesis, decision, and summary fields without losing earlier heartbeat context
+
+### Requirement: Observer normalizes run and iteration statuses
+The system SHALL map raw repo signals into normalized run and iteration statuses for the dashboard.
+
+#### Scenario: Run status is normalized from repo signals
+- **WHEN** the observer evaluates state timestamps, log freshness, stop reasons, and artifact completion
+- **THEN** it emits one run status from `Healthy`, `Busy`, `Waiting`, `Stalled`, `Failed`, `Blocked`, or `Completed`
+
+#### Scenario: Iteration status is normalized from artifact progress
+- **WHEN** the observer evaluates the selected iteration’s artifact and decision state
+- **THEN** it emits one iteration status from `Queued`, `In Progress`, `Decision Pending`, `Evaluated`, `Kept`, `Reverted`, `Follow-up`, or `Failed`
+
+### Requirement: Observer explains abnormal health conditions
+The system SHALL provide enough diagnosis context for the dashboard to explain why a run appears stalled, blocked, or failed.
+
+#### Scenario: Stalled run includes diagnosis signals
+- **WHEN** the observer classifies a run as stalled
+- **THEN** it includes the affected iteration, time since last heartbeat, and the stale signal used for classification so the dashboard can explain the condition without exposing raw file parsing details
+
+#### Scenario: Blocked or failed run includes source reason
+- **WHEN** the observer classifies a run as blocked or failed
+- **THEN** it includes the underlying stop or failure reason from the repo state or decision artifacts in normalized dashboard state

--- a/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/tasks.md
+++ b/openspec/changes/archive/2026-04-20-stargatey-research-dashboard/tasks.md
@@ -1,0 +1,39 @@
+## 1. Observer Foundation
+
+- [x] 1.1 Choose the smallest local dashboard runtime and document the chosen stack in the change implementation notes
+- [x] 1.2 Implement a normalized observer module that reads run state, iteration artifacts, logs, and `experiments/results.tsv`
+- [x] 1.3 Add focused tests for source ingestion, status normalization, and stale/blocked/failed detection using representative fixture data
+
+## 2. Home Page Live Monitor
+
+- [x] 2.1 Implement the home page shell with `Run Health Strip`, `Iteration Timeline`, `Selected Iteration Panel`, and support-panel layout
+- [x] 2.2 Render timeline nodes with hypothesis label, `drawdown`, `turnover`, `deflated_sr`, and `baseline delta`
+- [x] 2.3 Implement live refresh behavior so run health and active iteration state update as logs and artifacts change
+
+## 3. Iteration Analysis Views
+
+- [x] 3.1 Implement the selected-iteration panel using the fixed order: hypothesis diff, strategy diff, metric breakdown, decision reasoning
+- [x] 3.2 Implement an iteration detail page with drill-down views for artifacts, logs, and baseline comparisons
+- [x] 3.3 Add comparison helpers for `vs previous iteration`, `vs current baseline`, and `vs best iteration in current run`
+
+## 4. Health Diagnostics and Failure UX
+
+- [x] 4.1 Implement normalized run and iteration status mapping for healthy, waiting, stalled, blocked, failed, and completed conditions
+- [x] 4.2 Surface diagnosis details in the health strip and iteration views without requiring raw-file inspection
+- [x] 4.3 Add regression coverage for stalled, blocked, failed, and partial-artifact states
+
+## 5. Verification and Finish
+
+- [x] 5.1 Validate the dashboard against a real or representative active-run artifact tree under `experiments/iterations/`
+- [x] 5.2 Verify that the home page answers run health within 10 seconds and that iteration drill-downs show the expected diffs and reasoning
+- [x] 5.3 Update any implementation-facing docs needed to explain how to launch the dashboard and interpret its statuses
+- [x] 5.4 Make the representative dashboard validation deterministic so the home-page health expectation cannot age from `Healthy` into `Stalled` during later reruns
+- [x] 5.5 Tighten the representative dashboard validation to prove the home page stays healthy and the iteration detail page still shows the expected diffs and decision reasoning under the same fixture timing model
+- [x] 5.6 Re-run the full dashboard verification set and record clean evidence: representative integration test, full `pytest`, CLI help, browser validation, and no remaining known dashboard verification failures
+- [x] 5.7 Escape or safely render untrusted log excerpts, diagnosis text, and artifact/path fields so the dashboard cannot execute stored HTML or script content from repo-local artifacts
+- [x] 5.8 Resolve repo-relative artifact paths against the observed repository root and hide stale iteration timelines when there is no active run state
+- [x] 5.9 Stop attaching ledger rows to iterations by plain list index and make run-health heartbeat selection use the freshest viable signal across logs, artifacts, and state
+- [x] 5.10 Add regression coverage for escaped dashboard rendering, repo-relative artifact paths, no-active-run timeline behavior, ledger ambiguity handling, and freshest-heartbeat selection; then rerun the full dashboard verification set cleanly
+- [x] 5.11 Remove the single-row unkeyed ledger fallback so ledger metrics only attach to iterations with explicit, unambiguous iteration identifiers
+- [x] 5.12 Reset selected-iteration and detail-page panels to empty or missing placeholders when refreshed state has no matching iteration
+- [x] 5.13 Re-run the focused dashboard tests, full `pytest`, and a final review pass with no remaining Important findings

--- a/openspec/specs/research-dashboard-iteration-analysis/spec.md
+++ b/openspec/specs/research-dashboard-iteration-analysis/spec.md
@@ -1,0 +1,37 @@
+# research-dashboard-iteration-analysis Specification
+
+## Purpose
+TBD - created by archiving change stargatey-research-dashboard. Update Purpose after archive.
+## Requirements
+### Requirement: Dashboard explains the selected iteration in a fixed reading order
+The system SHALL render the selected iteration using a stable reading order that prioritizes research intent before quantitative evidence and decision outcome.
+
+#### Scenario: Selected iteration panel uses the approved section order
+- **WHEN** an operator selects an iteration from the timeline
+- **THEN** the dashboard shows `Hypothesis diff`, `Strategy diff`, `Metric breakdown`, and `Decision reasoning` in that order
+
+### Requirement: Dashboard provides drill-down detail for a single iteration
+The system SHALL provide a dedicated iteration detail view for deep inspection of one iteration.
+
+#### Scenario: Iteration detail page expands inspection depth
+- **WHEN** the operator opens an iteration detail view
+- **THEN** the page shows the iteration’s normalized status, hypothesis summary, strategy diff, metric breakdown, decision reasoning, and key artifact or log references for that iteration
+
+### Requirement: Dashboard compares each iteration against approved baselines
+The system SHALL support comparison of the selected iteration against the previous iteration, the current baseline, and the best iteration in the active run.
+
+#### Scenario: Metrics expose the three required comparison baselines
+- **WHEN** the dashboard renders metric details for a selected iteration
+- **THEN** it presents comparisons for `vs previous iteration`, `vs current baseline`, and `vs best iteration in current run`
+
+#### Scenario: Conceptual and code changes can be inspected together
+- **WHEN** an iteration has both hypothesis context and strategy changes
+- **THEN** the operator can inspect the hypothesis/decision diff and the strategy diff from the same iteration view without leaving the dashboard flow
+
+### Requirement: Dashboard distinguishes decision outcomes with reasons
+The system SHALL distinguish kept, reverted, follow-up, and failed iterations and explain why the outcome was assigned.
+
+#### Scenario: Decision reasoning is visible for a completed iteration
+- **WHEN** an iteration has a completed decision artifact
+- **THEN** the dashboard shows the normalized decision outcome and the recorded reasons for that outcome in the selected-iteration view and detail page
+

--- a/openspec/specs/research-dashboard-monitoring/spec.md
+++ b/openspec/specs/research-dashboard-monitoring/spec.md
@@ -1,0 +1,38 @@
+# research-dashboard-monitoring Specification
+
+## Purpose
+TBD - created by archiving change stargatey-research-dashboard. Update Purpose after archive.
+## Requirements
+### Requirement: Dashboard shows active run health first
+The system SHALL provide a home page that surfaces the active run’s health before any secondary dashboard content.
+
+#### Scenario: Healthy run summary is visible on page load
+- **WHEN** the operator opens the dashboard while an active run has fresh state or log activity
+- **THEN** the dashboard shows the run identifier, normalized status, active iteration, latest update time, and heartbeat freshness in a dedicated top-level run-health region
+
+#### Scenario: Blocked or failed run is summarized clearly
+- **WHEN** the observer detects a blocked, failed, or completed run state
+- **THEN** the run-health region shows the normalized status and the associated stop or failure reason without requiring the operator to inspect raw files
+
+### Requirement: Dashboard presents a timeline of active-run iterations
+The system SHALL present the active run as a timeline of iterations that emphasizes research-direction evolution and risk-adjusted change over time.
+
+#### Scenario: Latest iteration is selected by default
+- **WHEN** the dashboard loads an active run with one or more completed or in-progress iterations
+- **THEN** the latest iteration is selected automatically and highlighted in the timeline
+
+#### Scenario: Timeline nodes summarize key iteration signals
+- **WHEN** an iteration has enough structured data to render a timeline node
+- **THEN** the node shows the iteration number, a short hypothesis or direction label, `drawdown`, `turnover`, `deflated_sr`, and `baseline delta`
+
+### Requirement: Dashboard exposes dense support panels for live awareness
+The system SHALL provide secondary quant-monitor panels that increase live situational awareness without replacing the timeline as primary navigation.
+
+#### Scenario: Support panels show recent activity and trend context
+- **WHEN** the home page renders an active run
+- **THEN** the dashboard shows recent log activity, artifact availability, run-level performance trend, and recent decision summary in support panels adjacent to the main timeline and selected-iteration views
+
+#### Scenario: Support panels update as new iteration data lands
+- **WHEN** new log lines, artifacts, or ledger updates appear for the active run
+- **THEN** the related support panels refresh to reflect the latest available information without requiring a full page reload
+

--- a/openspec/specs/research-dashboard-observer/spec.md
+++ b/openspec/specs/research-dashboard-observer/spec.md
@@ -1,0 +1,45 @@
+# research-dashboard-observer Specification
+
+## Purpose
+TBD - created by archiving change stargatey-research-dashboard. Update Purpose after archive.
+## Requirements
+### Requirement: Observer ingests repo-local run and iteration sources
+The system SHALL ingest the current run state, per-iteration artifacts, per-iteration logs, and results ledger data from the local repository.
+
+#### Scenario: Observer reads all required source classes
+- **WHEN** the dashboard backend refreshes the active run
+- **THEN** it reads `experiments/autoresearch_state.json`, relevant files under `experiments/iterations/<run_id>/`, and `experiments/results.tsv` to build dashboard state
+
+### Requirement: Observer prioritizes source freshness by role
+The system SHALL treat logs as the primary heartbeat source, structured artifacts as the primary semantic source, and the results ledger as the confirmation source for landed metrics.
+
+#### Scenario: Heartbeat appears before ledger confirmation
+- **WHEN** new log output exists for an active iteration but no new ledger row has been written yet
+- **THEN** the dashboard still marks the run as active based on log freshness while deferring ledger-confirmed metric state until results data arrives
+
+#### Scenario: Structured meaning appears after raw activity
+- **WHEN** `decision.json` or `iteration_record.json` is written after earlier log activity
+- **THEN** the observer enriches the affected iteration with hypothesis, decision, and summary fields without losing earlier heartbeat context
+
+### Requirement: Observer normalizes run and iteration statuses
+The system SHALL map raw repo signals into normalized run and iteration statuses for the dashboard.
+
+#### Scenario: Run status is normalized from repo signals
+- **WHEN** the observer evaluates state timestamps, log freshness, stop reasons, and artifact completion
+- **THEN** it emits one run status from `Healthy`, `Busy`, `Waiting`, `Stalled`, `Failed`, `Blocked`, or `Completed`
+
+#### Scenario: Iteration status is normalized from artifact progress
+- **WHEN** the observer evaluates the selected iteration’s artifact and decision state
+- **THEN** it emits one iteration status from `Queued`, `In Progress`, `Decision Pending`, `Evaluated`, `Kept`, `Reverted`, `Follow-up`, or `Failed`
+
+### Requirement: Observer explains abnormal health conditions
+The system SHALL provide enough diagnosis context for the dashboard to explain why a run appears stalled, blocked, or failed.
+
+#### Scenario: Stalled run includes diagnosis signals
+- **WHEN** the observer classifies a run as stalled
+- **THEN** it includes the affected iteration, time since last heartbeat, and the stale signal used for classification so the dashboard can explain the condition without exposing raw file parsing details
+
+#### Scenario: Blocked or failed run includes source reason
+- **WHEN** the observer classifies a run as blocked or failed
+- **THEN** it includes the underlying stop or failure reason from the repo state or decision artifacts in normalized dashboard state
+

--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""Read-only dashboard support for Quant Autoresearch."""
+
+from .observer import observe_dashboard_state
+
+__all__ = ["observe_dashboard_state"]

--- a/src/dashboard/observer.py
+++ b/src/dashboard/observer.py
@@ -1,0 +1,790 @@
+from __future__ import annotations
+
+import csv
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+STATE_PATH = Path("experiments/autoresearch_state.json")
+ITERATION_ROOT = Path("experiments/iterations")
+RESULTS_PATH = Path("experiments/results.tsv")
+ITERATION_DIR_PATTERN = re.compile(r"^iteration-(?P<number>\d+)$")
+
+
+def observe_dashboard_state(
+    repo_root: str | Path,
+    *,
+    now: datetime | None = None,
+    stale_after_seconds: int = 600,
+) -> dict[str, Any]:
+    """Read repo-local autoresearch artifacts into a normalized dashboard state."""
+    root = Path(repo_root).expanduser().resolve()
+    observed_at = _normalize_datetime(now or datetime.now(timezone.utc))
+    state_path = root / STATE_PATH
+    iteration_root = root / ITERATION_ROOT
+    results_path = root / RESULTS_PATH
+
+    raw_state = _read_json(state_path)
+    has_run_state = isinstance(raw_state, dict)
+    state = raw_state
+    if not has_run_state:
+        state = {}
+
+    run_root = _resolve_run_root(iteration_root, state.get("run_id"), allow_latest=has_run_state)
+    ledger = _read_results_ledger(results_path)
+    iterations = _collect_iterations(root, run_root, ledger["rows"])
+    heartbeat = _latest_heartbeat(run_root, state_path, state, observed_at)
+    run = _normalize_run(state, heartbeat, observed_at, stale_after_seconds)
+
+    return {
+        "observed_at": observed_at.isoformat(),
+        "run": run,
+        "iterations": iterations,
+        "ledger": ledger,
+        "sources": {
+            "state": _source_status(state_path),
+            "iteration_root": _source_status(iteration_root),
+            "active_run_root": _source_status(run_root) if run_root is not None else None,
+            "results": _source_status(results_path),
+        },
+    }
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _read_json(path: Path) -> Any:
+    if not path.exists() or not path.is_file():
+        return None
+
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _source_status(path: Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "exists": path.exists(),
+    }
+
+
+def _resolve_run_root(iteration_root: Path, run_id: Any, *, allow_latest: bool = True) -> Path | None:
+    if isinstance(run_id, str) and run_id:
+        return iteration_root / run_id
+
+    if not allow_latest or not iteration_root.exists():
+        return None
+
+    run_dirs = [path for path in iteration_root.iterdir() if path.is_dir()]
+    if not run_dirs:
+        return None
+
+    return max(run_dirs, key=lambda path: path.stat().st_mtime)
+
+
+def _read_results_ledger(path: Path) -> dict[str, Any]:
+    if not path.exists() or not path.is_file():
+        return {
+            "path": str(path),
+            "columns": [],
+            "rows": [],
+        }
+
+    rows: list[dict[str, Any]] = []
+    with path.open(newline="", encoding="utf-8", errors="ignore") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        columns = reader.fieldnames or []
+        for row in reader:
+            rows.append({key: _coerce_scalar(value) for key, value in row.items()})
+
+    return {
+        "path": str(path),
+        "columns": columns,
+        "rows": rows,
+    }
+
+
+def _coerce_scalar(value: Any) -> Any:
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        return value
+
+    try:
+        numeric = float(value)
+    except ValueError:
+        return value
+
+    if numeric.is_integer() and "." not in value:
+        return int(numeric)
+    return numeric
+
+
+def _collect_iterations(
+    repo_root: Path,
+    run_root: Path | None,
+    ledger_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if run_root is None or not run_root.exists():
+        return []
+
+    iteration_dirs = [path for path in run_root.iterdir() if path.is_dir() and _iteration_number(path) is not None]
+    iteration_dirs.sort(key=lambda path: _iteration_number(path) or 0)
+    ledger_by_iteration = _ledger_rows_by_iteration(iteration_dirs, ledger_rows)
+
+    iterations: list[dict[str, Any]] = []
+    for iteration_dir in iteration_dirs:
+        iteration_number = _iteration_number(iteration_dir)
+        ledger_row = ledger_by_iteration.get(iteration_number, {}) if iteration_number is not None else {}
+        iterations.append(_normalize_iteration(repo_root, iteration_dir, ledger_row))
+
+    best_iteration = _best_iteration(iterations)
+    for index, iteration in enumerate(iterations):
+        previous = iterations[index - 1] if index > 0 else None
+        iteration["analysis"] = _iteration_analysis(iteration, previous)
+        iteration["metric_breakdown"] = _metric_breakdown(iteration, previous, best_iteration)
+    return iterations
+
+
+def _iteration_number(path: Path) -> int | None:
+    match = ITERATION_DIR_PATTERN.match(path.name)
+    if not match:
+        return None
+    return int(match.group("number"))
+
+
+def _ledger_rows_by_iteration(
+    iteration_dirs: list[Path],
+    ledger_rows: list[dict[str, Any]],
+) -> dict[int, dict[str, Any]]:
+    if not ledger_rows:
+        return {}
+
+    correlated: dict[int, dict[str, Any]] = {}
+    ambiguous: set[int] = set()
+    for row in ledger_rows:
+        iteration_number = _ledger_iteration_number(row)
+        if iteration_number is None:
+            continue
+        if iteration_number in correlated:
+            ambiguous.add(iteration_number)
+            continue
+        correlated[iteration_number] = row
+
+    for iteration_number in ambiguous:
+        correlated.pop(iteration_number, None)
+    return correlated
+
+
+def _ledger_iteration_number(row: dict[str, Any]) -> int | None:
+    for key in ("iteration", "iteration_number", "iteration_index", "round", "round_number"):
+        iteration_number = _integer_identifier(row.get(key))
+        if iteration_number is not None:
+            return iteration_number
+
+    for key in ("iteration_dir", "iteration_path", "artifact_iteration_dir", "artifact_path"):
+        value = row.get(key)
+        if isinstance(value, str):
+            match = ITERATION_DIR_PATTERN.search(Path(value).name)
+            if match:
+                return int(match.group("number"))
+    return None
+
+
+def _integer_identifier(value: Any) -> int | None:
+    if isinstance(value, bool) or value in (None, ""):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else None
+    if not isinstance(value, str):
+        return None
+
+    stripped = value.strip()
+    if stripped.isdigit():
+        return int(stripped)
+    match = ITERATION_DIR_PATTERN.match(stripped)
+    if match:
+        return int(match.group("number"))
+    return None
+
+
+def _normalize_iteration(repo_root: Path, iteration_dir: Path, ledger_row: dict[str, Any]) -> dict[str, Any]:
+    record_path = iteration_dir / "iteration_record.json"
+    decision_path = iteration_dir / "decision.json"
+    record = _read_json(record_path)
+    if not isinstance(record, dict):
+        record = {}
+    decision_payload = _read_json(decision_path)
+    if not isinstance(decision_payload, dict):
+        decision_payload = {}
+
+    decision_value = _decision_value(record, decision_payload)
+    decision_reasons = _decision_reasons(record, decision_payload)
+    metrics = _iteration_metrics(record, decision_payload, ledger_row)
+    logs = _iteration_logs(iteration_dir)
+
+    summary = record.get("summary") if isinstance(record.get("summary"), dict) else {}
+    artifact_status = record.get("artifact_status")
+    artifact_paths = record.get("artifact_paths") if isinstance(record.get("artifact_paths"), dict) else {}
+    artifact_references = _artifact_references(repo_root, iteration_dir, artifact_paths, record_path, decision_path)
+    status = _iteration_status(record, decision_value, artifact_status, logs)
+
+    return {
+        "iteration": _iteration_number(iteration_dir),
+        "path": str(iteration_dir),
+        "status": status,
+        "artifact_status": artifact_status,
+        "execution_mode": record.get("execution_mode"),
+        "hypothesis": record.get("hypothesis") or summary.get("hypothesis"),
+        "strategy_change_summary": record.get("strategy_change_summary") or summary.get("strategy_change_summary"),
+        "files_touched": record.get("files_touched") or summary.get("files_touched") or [],
+        "decision": decision_value,
+        "decision_reasons": decision_reasons,
+        "metrics": metrics,
+        "logs": logs,
+        "artifacts": {item["name"]: item["exists"] for item in artifact_references},
+        "artifact_references": artifact_references,
+        "diagnosis": _iteration_diagnosis(
+            status=status,
+            artifact_references=artifact_references,
+            decision_reasons=decision_reasons,
+            record=record,
+            metrics=metrics,
+        ),
+    }
+
+
+def _artifact_references(
+    repo_root: Path,
+    iteration_dir: Path,
+    artifact_paths: dict[str, Any],
+    record_path: Path,
+    decision_path: Path,
+) -> list[dict[str, Any]]:
+    known_paths = {
+        "context_json": iteration_dir / "context.json",
+        "context_markdown": iteration_dir / "context.md",
+        "decision": decision_path,
+        "iteration_record": record_path,
+        "experiment_note_draft": iteration_dir / "experiment_note_draft.md",
+    }
+    references: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for name, default_path in known_paths.items():
+        path = _artifact_path(repo_root, artifact_paths.get(name), default_path)
+        references.append({"name": name, "path": str(path), "exists": path.exists()})
+        seen.add(name)
+
+    for name, value in sorted(artifact_paths.items()):
+        if name in seen:
+            continue
+        path = _artifact_path(repo_root, value, iteration_dir / str(value))
+        references.append({"name": str(name), "path": str(path), "exists": path.exists()})
+
+    return references
+
+
+def _artifact_path(repo_root: Path, value: Any, default_path: Path) -> Path:
+    if not isinstance(value, str) or not value:
+        return default_path
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return path
+    return repo_root / path
+
+
+def _best_iteration(iterations: list[dict[str, Any]]) -> dict[str, Any] | None:
+    scored = [
+        iteration
+        for iteration in iterations
+        if _as_float((iteration.get("metrics") or {}).get("score")) is not None
+    ]
+    if not scored:
+        return None
+    return max(scored, key=lambda iteration: _as_float((iteration.get("metrics") or {}).get("score")) or float("-inf"))
+
+
+def _iteration_analysis(
+    iteration: dict[str, Any],
+    previous: dict[str, Any] | None,
+) -> dict[str, str]:
+    hypothesis = _display_text(iteration.get("hypothesis"), "No hypothesis reported.")
+    previous_hypothesis = _display_text(previous.get("hypothesis"), "No previous hypothesis.") if previous else None
+    strategy = _display_text(iteration.get("strategy_change_summary"), "No strategy change summary reported.")
+    previous_strategy = (
+        _display_text(previous.get("strategy_change_summary"), "No previous strategy summary.") if previous else None
+    )
+    files_touched = [str(path) for path in iteration.get("files_touched") or []]
+
+    strategy_lines = []
+    if previous_strategy is not None:
+        strategy_lines.append(f"Previous: {previous_strategy}")
+    else:
+        strategy_lines.append("Previous: No previous iteration.")
+    strategy_lines.append(f"Current: {strategy}")
+    if files_touched:
+        strategy_lines.append("Files touched:")
+        strategy_lines.extend(f"- {path}" for path in files_touched)
+
+    return {
+        "hypothesis_diff": "\n".join(
+            [
+                (
+                    f"Previous: {previous_hypothesis}"
+                    if previous_hypothesis is not None
+                    else "Previous: No previous iteration."
+                ),
+                f"Current: {hypothesis}",
+            ]
+        ),
+        "strategy_diff": "\n".join(strategy_lines),
+    }
+
+
+def _display_text(value: Any, fallback: str) -> str:
+    if value in (None, ""):
+        return fallback
+    return str(value)
+
+
+def _metric_breakdown(
+    iteration: dict[str, Any],
+    previous: dict[str, Any] | None,
+    best_iteration: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "current": iteration.get("metrics") or {},
+        "comparisons": _metric_comparisons(iteration, previous, best_iteration),
+    }
+
+
+def _metric_comparisons(
+    iteration: dict[str, Any],
+    previous: dict[str, Any] | None,
+    best_iteration: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    return [
+        _iteration_comparison("vs previous iteration", iteration, previous),
+        _baseline_comparison(iteration),
+        _iteration_comparison("vs best iteration in current run", iteration, best_iteration),
+    ]
+
+
+def _iteration_comparison(
+    label: str,
+    iteration: dict[str, Any],
+    reference: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if reference is None:
+        return {
+            "label": label,
+            "reference_iteration": None,
+            "deltas": {},
+            "summary": "No comparison iteration available.",
+        }
+
+    deltas = _metric_deltas(iteration.get("metrics") or {}, reference.get("metrics") or {})
+    return {
+        "label": label,
+        "reference_iteration": reference.get("iteration"),
+        "deltas": deltas,
+        "summary": _comparison_summary(deltas),
+    }
+
+
+def _baseline_comparison(iteration: dict[str, Any]) -> dict[str, Any]:
+    metrics = iteration.get("metrics") or {}
+    score = _as_float(metrics.get("score"))
+    baseline = _as_float(metrics.get("baseline_sharpe"))
+    if score is None or baseline is None:
+        return {
+            "label": "vs current baseline",
+            "reference_iteration": None,
+            "deltas": {},
+            "summary": "No baseline metric available.",
+        }
+
+    deltas = {"score": score - baseline}
+    return {
+        "label": "vs current baseline",
+        "reference_iteration": None,
+        "reference_metric": "baseline_sharpe",
+        "reference_value": baseline,
+        "deltas": deltas,
+        "summary": _comparison_summary(deltas),
+    }
+
+
+def _metric_deltas(current: dict[str, Any], reference: dict[str, Any]) -> dict[str, float]:
+    deltas: dict[str, float] = {}
+    for key in ("score", "deflated_sr", "drawdown", "turnover", "trades", "baseline_delta"):
+        current_value = _as_float(current.get(key))
+        reference_value = _as_float(reference.get(key))
+        if current_value is not None and reference_value is not None:
+            deltas[key] = current_value - reference_value
+    return deltas
+
+
+def _comparison_summary(deltas: dict[str, float]) -> str:
+    if not deltas:
+        return "No comparable metrics available."
+    return "; ".join(f"{key}: {value:+.6g}" for key, value in deltas.items())
+
+
+def _decision_value(record: dict[str, Any], decision_payload: dict[str, Any]) -> str | None:
+    record_decision = record.get("decision")
+    if isinstance(record_decision, dict):
+        return _string_or_none(record_decision.get("decision"))
+    if isinstance(record_decision, str):
+        return record_decision
+    return _string_or_none(decision_payload.get("decision"))
+
+
+def _decision_reasons(record: dict[str, Any], decision_payload: dict[str, Any]) -> list[str]:
+    for candidate in (
+        record.get("decision_reason"),
+        record.get("decision_reasons"),
+        decision_payload.get("reasons"),
+        record.get("decision", {}).get("reasons") if isinstance(record.get("decision"), dict) else None,
+    ):
+        if isinstance(candidate, list):
+            return [str(item) for item in candidate]
+        if isinstance(candidate, str):
+            return [candidate]
+    return []
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _iteration_metrics(
+    record: dict[str, Any],
+    decision_payload: dict[str, Any],
+    ledger_row: dict[str, Any],
+) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+
+    evaluation_summary = record.get("evaluation_summary")
+    if isinstance(evaluation_summary, dict):
+        metrics.update(evaluation_summary)
+
+    record_decision = record.get("decision")
+    if isinstance(record_decision, dict):
+        metrics.update(record_decision)
+
+    metrics.update(decision_payload)
+    metrics.update(ledger_row)
+
+    score = _as_float(metrics.get("score"))
+    baseline = _as_float(metrics.get("baseline_sharpe"))
+    if score is not None and baseline is not None:
+        metrics["baseline_delta"] = score - baseline
+
+    return metrics
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _iteration_logs(iteration_dir: Path) -> list[dict[str, Any]]:
+    logs = []
+    for path in sorted(iteration_dir.glob("*.log")):
+        logs.append(
+            {
+                "path": str(path),
+                "updated_at": _datetime_from_mtime(path).isoformat(),
+                "excerpt": _read_text_excerpt(path),
+            }
+        )
+    return logs
+
+
+def _read_text_excerpt(path: Path, max_chars: int = 1000) -> str:
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:]
+
+
+def _iteration_status(
+    record: dict[str, Any],
+    decision_value: str | None,
+    artifact_status: Any,
+    logs: list[dict[str, Any]],
+) -> str:
+    normalized_decision = (decision_value or "").lower().replace("_", "-")
+    normalized_artifact_status = str(artifact_status or "").lower()
+
+    if normalized_artifact_status == "failed" or normalized_decision == "failed":
+        return "Failed"
+    if normalized_decision == "keep":
+        return "Kept"
+    if normalized_decision == "revert":
+        return "Reverted"
+    if normalized_decision in {"follow-up", "followup"}:
+        return "Follow-up"
+    if normalized_decision == "pending-evaluation":
+        return "Decision Pending"
+    if normalized_artifact_status in {"completed", "simulated"} and not normalized_decision:
+        return "Decision Pending"
+    if normalized_artifact_status in {"running", "in-progress", "in_progress", "started"}:
+        return "In Progress"
+    if normalized_artifact_status in {"queued", "pending", "created"}:
+        return "Queued"
+    if record:
+        return "Evaluated"
+    if logs:
+        return "In Progress"
+    return "Queued"
+
+
+def _iteration_diagnosis(
+    *,
+    status: str,
+    artifact_references: list[dict[str, Any]],
+    decision_reasons: list[str],
+    record: dict[str, Any],
+    metrics: dict[str, Any],
+) -> dict[str, Any] | None:
+    available_artifacts = [item["name"] for item in artifact_references if item.get("exists")]
+    missing_artifacts = [item["name"] for item in artifact_references if not item.get("exists")]
+
+    if status == "Failed":
+        details = decision_reasons or _iteration_failure_details(record, metrics)
+        return {
+            "reason": "failed_iteration",
+            "details": details or ["Iteration failed before producing a successful decision."],
+            "available_artifacts": available_artifacts,
+            "missing_artifacts": missing_artifacts,
+        }
+    if status == "Decision Pending":
+        return {
+            "reason": "decision_pending",
+            "details": ["Awaiting decision artifact or final keep/revert outcome."],
+            "available_artifacts": available_artifacts,
+            "missing_artifacts": [name for name in ("decision",) if name in missing_artifacts],
+        }
+    if status == "In Progress":
+        return {
+            "reason": "artifacts_pending",
+            "details": ["Iteration is still active and has not produced all expected artifacts yet."],
+            "available_artifacts": available_artifacts,
+            "missing_artifacts": [name for name in ("iteration_record", "decision") if name in missing_artifacts],
+        }
+    if status == "Queued":
+        return {
+            "reason": "queued",
+            "details": ["No iteration logs or decision artifacts detected yet."],
+            "available_artifacts": available_artifacts,
+            "missing_artifacts": [name for name in ("iteration_record", "decision") if name in missing_artifacts],
+        }
+    if decision_reasons:
+        return {
+            "reason": "decision_recorded",
+            "details": decision_reasons,
+            "available_artifacts": available_artifacts,
+            "missing_artifacts": [],
+        }
+    return None
+
+
+def _iteration_failure_details(record: dict[str, Any], metrics: dict[str, Any]) -> list[str]:
+    evaluation_summary = record.get("evaluation_summary")
+    if isinstance(evaluation_summary, dict):
+        error = evaluation_summary.get("error")
+        if error:
+            return [str(error)]
+    error = metrics.get("error")
+    if error:
+        return [str(error)]
+    return []
+
+
+def _latest_heartbeat(
+    run_root: Path | None,
+    state_path: Path,
+    state: dict[str, Any],
+    observed_at: datetime,
+) -> dict[str, Any]:
+    log_candidates: list[tuple[datetime, str, Path | None]] = []
+    artifact_candidates: list[tuple[datetime, str, Path | None]] = []
+    state_candidates: list[tuple[datetime, str, Path | None]] = []
+
+    if run_root is not None and run_root.exists():
+        for path in run_root.rglob("*.log"):
+            log_candidates.append((_datetime_from_mtime(path), "log", path))
+        for pattern in ("iteration_record.json", "decision.json", "context.json"):
+            for path in run_root.rglob(pattern):
+                artifact_candidates.append((_datetime_from_mtime(path), "artifact", path))
+
+    state_updated_at = _parse_datetime(state.get("updated_at"))
+    if state_updated_at is not None:
+        state_candidates.append((state_updated_at, "state", state_path))
+    elif state_path.exists():
+        state_candidates.append((_datetime_from_mtime(state_path), "state", state_path))
+
+    candidates = log_candidates + artifact_candidates + state_candidates
+    if not candidates:
+        return {
+            "source_role": None,
+            "path": None,
+            "updated_at": None,
+            "age_seconds": None,
+        }
+
+    viable_candidates = [candidate for candidate in candidates if candidate[0] <= observed_at]
+    if viable_candidates:
+        candidates = viable_candidates
+
+    updated_at, source_role, path = max(candidates, key=lambda candidate: candidate[0])
+    return {
+        "source_role": source_role,
+        "path": str(path) if path is not None else None,
+        "updated_at": updated_at.isoformat(),
+        "age_seconds": max(0.0, (observed_at - updated_at).total_seconds()),
+    }
+
+
+def _datetime_from_mtime(path: Path) -> datetime:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return _normalize_datetime(parsed)
+
+
+def _normalize_run(
+    state: dict[str, Any],
+    heartbeat: dict[str, Any],
+    observed_at: datetime,
+    stale_after_seconds: int,
+) -> dict[str, Any]:
+    del observed_at
+    heartbeat_age = heartbeat.get("age_seconds")
+    raw_status = str(state.get("status") or "missing").lower()
+    active_iteration = state.get("active_iteration")
+    status = _run_status(raw_status, active_iteration, heartbeat_age, stale_after_seconds, bool(state))
+    diagnosis = _run_diagnosis(state, status, heartbeat)
+
+    return {
+        "run_id": state.get("run_id"),
+        "status": status,
+        "raw_status": state.get("status"),
+        "active_iteration": active_iteration,
+        "current_iteration": state.get("current_iteration"),
+        "iteration_budget": state.get("iteration_budget"),
+        "latest_update": heartbeat.get("updated_at") or state.get("updated_at"),
+        "best_score": state.get("best_score"),
+        "best_iteration": state.get("best_iteration"),
+        "stop_reason": state.get("stop_reason"),
+        "heartbeat": heartbeat,
+        "diagnosis": diagnosis,
+    }
+
+
+def _run_status(
+    raw_status: str,
+    active_iteration: Any,
+    heartbeat_age: Any,
+    stale_after_seconds: int,
+    has_state: bool,
+) -> str:
+    if raw_status == "blocked":
+        return "Blocked"
+    if raw_status == "failed":
+        return "Failed"
+    if raw_status == "completed":
+        return "Completed"
+    if not has_state:
+        return "Waiting"
+    if heartbeat_age is not None and heartbeat_age > stale_after_seconds:
+        return "Stalled"
+    if active_iteration not in (None, "", 0):
+        return "Busy"
+    if raw_status == "running":
+        return "Healthy"
+    return "Waiting"
+
+
+def _run_diagnosis(
+    state: dict[str, Any],
+    status: str,
+    heartbeat: dict[str, Any],
+) -> dict[str, Any] | None:
+    if status == "Waiting":
+        if not state:
+            return {
+                "reason": "awaiting_state",
+                "details": ["No active run state file detected yet."],
+            }
+        return {
+            "reason": "awaiting_activity",
+            "details": ["Run state exists but there is no active iteration or fresh heartbeat yet."],
+        }
+    if status == "Stalled":
+        return {
+            "reason": "heartbeat_stale",
+            "affected_iteration": state.get("active_iteration") or state.get("current_iteration"),
+            "time_since_heartbeat_seconds": heartbeat.get("age_seconds"),
+            "stale_signal": heartbeat.get("source_role"),
+            "path": heartbeat.get("path"),
+        }
+    if status in {"Blocked", "Failed"}:
+        return {
+            "reason": state.get("stop_reason") or state.get("last_error") or status.lower(),
+            "details": _state_failure_details(state),
+        }
+    if status == "Completed" and state.get("stop_reason"):
+        details: list[str] = []
+        last_completed_iteration = state.get("last_completed_iteration")
+        if last_completed_iteration not in (None, ""):
+            details.append(f"last_completed_iteration={last_completed_iteration}")
+        return {
+            "reason": state.get("stop_reason"),
+            "details": details,
+        }
+    return None
+
+
+def _state_failure_details(state: dict[str, Any]) -> list[str]:
+    last_decision = state.get("last_decision")
+    if isinstance(last_decision, dict):
+        reasons = last_decision.get("reasons")
+        if isinstance(reasons, list):
+            return [str(reason) for reason in reasons]
+        if isinstance(reasons, str):
+            return [reasons]
+
+    last_error = state.get("last_error")
+    if isinstance(last_error, str) and last_error:
+        return [part.strip() for part in last_error.split(";") if part.strip()]
+    return []

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1,0 +1,789 @@
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from .observer import observe_dashboard_state
+
+
+def render_dashboard_index(*, refresh_seconds: float = 3.0) -> str:
+    """Render the read-only dashboard shell."""
+    refresh_milliseconds = max(1, int(refresh_seconds * 1000))
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Quant Autoresearch Live Monitor</title>
+  <style>
+    :root {{
+      color-scheme: dark;
+      --bg: #090c10;
+      --panel: rgba(17, 23, 31, 0.84);
+      --panel-strong: rgba(25, 35, 46, 0.96);
+      --line: rgba(141, 232, 255, 0.22);
+      --ink: #e9f7ff;
+      --muted: #90a8b5;
+      --cyan: #56e4ff;
+      --lime: #c6ff5c;
+      --amber: #ffcc66;
+      --red: #ff6b7a;
+      --shadow: 0 22px 80px rgba(0, 0, 0, 0.45);
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      min-height: 100vh;
+      margin: 0;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at 18% 12%, rgba(86, 228, 255, 0.18), transparent 30rem),
+        radial-gradient(circle at 82% 18%, rgba(198, 255, 92, 0.10), transparent 28rem),
+        linear-gradient(135deg, #06080c 0%, #0d1218 54%, #11171f 100%);
+      font-family: "Avenir Next", "Gill Sans", "Trebuchet MS", sans-serif;
+      letter-spacing: 0.01em;
+    }}
+    main {{
+      width: min(1500px, calc(100vw - 40px));
+      margin: 0 auto;
+      padding: 32px 0 44px;
+    }}
+    .masthead {{
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 24px;
+      margin-bottom: 20px;
+    }}
+    h1 {{
+      margin: 0;
+      font-family: "Copperplate", "Avenir Next", sans-serif;
+      font-size: clamp(2rem, 5vw, 4.8rem);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }}
+    .eyebrow {{
+      color: var(--cyan);
+      font-size: 0.78rem;
+      font-weight: 800;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+    }}
+    .refresh {{
+      color: var(--muted);
+      text-align: right;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      font-size: 0.74rem;
+    }}
+    .grid {{
+      display: grid;
+      grid-template-columns: minmax(320px, 0.95fr) minmax(420px, 1.35fr) minmax(260px, 0.7fr);
+      gap: 18px;
+    }}
+    .panel {{
+      border: 1px solid var(--line);
+      border-radius: 26px;
+      background: var(--panel);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }}
+    .panel h2, .panel h3 {{
+      margin: 0;
+      padding: 18px 20px 12px;
+      font-size: 0.82rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--cyan);
+      border-bottom: 1px solid var(--line);
+    }}
+    .panel-title-row {{
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }}
+    .open-detail-link {{
+      color: var(--lime);
+      font-size: 0.68rem;
+      text-decoration: none;
+      letter-spacing: 0.12em;
+    }}
+    .health {{
+      display: grid;
+      grid-column: 1 / -1;
+      grid-template-columns: repeat(6, minmax(130px, 1fr));
+      gap: 1px;
+      background: var(--line);
+      margin-bottom: 18px;
+    }}
+    .health > div {{
+      min-height: 104px;
+      padding: 18px;
+      background: var(--panel-strong);
+    }}
+    .label {{
+      color: var(--muted);
+      font-size: 0.72rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }}
+    .value {{
+      margin-top: 8px;
+      font-size: clamp(1.05rem, 2vw, 1.7rem);
+      font-weight: 800;
+      word-break: break-word;
+    }}
+    .status-healthy, .status-busy, .status-kept {{ color: var(--lime); }}
+    .status-waiting, .status-decision-pending, .status-evaluated {{ color: var(--amber); }}
+    .status-stalled, .status-blocked, .status-failed {{ color: var(--red); }}
+    .timeline-list {{
+      display: grid;
+      gap: 12px;
+      padding: 18px;
+      max-height: 670px;
+      overflow: auto;
+    }}
+    .node {{
+      width: 100%;
+      padding: 16px;
+      border: 1px solid rgba(255,255,255,0.10);
+      border-radius: 18px;
+      color: inherit;
+      background: rgba(255,255,255,0.035);
+      text-align: left;
+      cursor: pointer;
+    }}
+    .node[aria-selected="true"] {{
+      border-color: var(--cyan);
+      background: linear-gradient(135deg, rgba(86, 228, 255, 0.18), rgba(198, 255, 92, 0.08));
+    }}
+    .node-title {{
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      font-weight: 800;
+    }}
+    .metric-row {{
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+      margin-top: 14px;
+    }}
+    .metric {{
+      padding: 10px;
+      border-radius: 12px;
+      background: rgba(0,0,0,0.22);
+    }}
+    .metric strong {{
+      display: block;
+      margin-top: 4px;
+    }}
+    .detail-section {{
+      padding: 18px 20px;
+      border-bottom: 1px solid var(--line);
+    }}
+    .detail-section:last-child {{ border-bottom: 0; }}
+    pre {{
+      white-space: pre-wrap;
+      margin: 8px 0 0;
+      font-family: "SFMono-Regular", "Menlo", monospace;
+      font-size: 0.82rem;
+    }}
+    .support {{
+      display: grid;
+      gap: 18px;
+    }}
+    .support .panel div {{
+      padding: 16px 18px;
+      color: var(--muted);
+      line-height: 1.5;
+      white-space: pre-wrap;
+    }}
+    .empty {{
+      padding: 22px;
+      color: var(--muted);
+    }}
+    @media (max-width: 1120px) {{
+      .grid {{ grid-template-columns: 1fr; }}
+      .health {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <header class="masthead">
+      <div>
+        <div class="eyebrow">Read-only local cockpit</div>
+        <h1>Research Monitor</h1>
+      </div>
+      <div class="refresh">Live refresh · <span id="refresh-rate">{refresh_seconds:g}s</span><br><span id="last-refresh">Booting</span></div>
+    </header>
+
+    <section class="panel health" aria-label="Run Health Strip" id="run-health-strip">
+      <div><span class="label">Run Health Strip</span><div class="value">Loading</div></div>
+    </section>
+
+    <section class="grid">
+      <aside class="panel">
+        <h2>Iteration Timeline</h2>
+        <div class="timeline-list" id="iteration-timeline"><div class="empty">Waiting for iterations…</div></div>
+      </aside>
+
+      <section class="panel" id="selected-iteration-panel">
+        <h2 class="panel-title-row">Selected Iteration Panel <a class="open-detail-link" id="open-detail-link" href="#">Open detail page</a></h2>
+        <div class="detail-section"><span class="label">Hypothesis diff</span><pre id="hypothesis-diff">No iteration selected.</pre></div>
+        <div class="detail-section"><span class="label">Strategy diff</span><pre id="strategy-diff">No strategy change yet.</pre></div>
+        <div class="detail-section"><span class="label">Metric breakdown</span><pre id="metric-breakdown">No metrics yet.</pre></div>
+        <div class="detail-section"><span class="label">Decision reasoning</span><pre id="decision-reasoning">No decision yet.</pre></div>
+      </section>
+
+      <aside class="support">
+        <section class="panel"><h3>Recent Activity</h3><div id="recent-activity">No logs yet.</div></section>
+        <section class="panel"><h3>Artifact Availability</h3><div id="artifact-availability">No artifacts yet.</div></section>
+        <section class="panel"><h3>Performance Trend</h3><div id="performance-trend">No ledger data yet.</div></section>
+        <section class="panel"><h3>Decision Summary</h3><div id="decision-summary">No decisions yet.</div></section>
+      </aside>
+    </section>
+  </main>
+  <script>
+    const refreshMs = {refresh_milliseconds};
+    let selectedIteration = null;
+    const text = value => value === null || value === undefined || value === "" ? "—" : String(value);
+    const escapeHtml = value => text(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+    const metric = (metrics, key) => text(metrics && metrics[key]);
+    const statusClass = value => `status-${{text(value).toLowerCase().replaceAll(" ", "-").replace(/[^a-z0-9_-]/g, "-")}}`;
+    const formatDiagnosis = (diagnosis, fallback = null) => {{
+      const lines = [];
+      if (diagnosis && diagnosis.reason) {{
+        lines.push(text(diagnosis.reason));
+      }} else if (fallback) {{
+        lines.push(text(fallback));
+      }}
+      (diagnosis && diagnosis.details ? diagnosis.details : []).forEach(detail => lines.push(`- ${{text(detail)}}`));
+      if (diagnosis && diagnosis.time_since_heartbeat_seconds !== undefined && diagnosis.time_since_heartbeat_seconds !== null) {{
+        lines.push(`heartbeat_age=${{text(diagnosis.time_since_heartbeat_seconds)}}s`);
+      }}
+      if (diagnosis && diagnosis.missing_artifacts && diagnosis.missing_artifacts.length) {{
+        lines.push(`missing=${{diagnosis.missing_artifacts.join(', ')}}`);
+      }}
+      return lines.join('\\n') || '—';
+    }};
+
+    function renderHealth(run) {{
+      const heartbeat = run.heartbeat || {{}};
+      const diagnosis = run.diagnosis || {{}};
+      document.querySelector('#run-health-strip').innerHTML = `
+        <div><span class="label">Run Health Strip</span><div class="value ${{statusClass(run.status)}}">${{escapeHtml(run.status)}}</div></div>
+        <div><span class="label">Run ID</span><div class="value">${{escapeHtml(run.run_id)}}</div></div>
+        <div><span class="label">Active iteration</span><div class="value">${{escapeHtml(run.active_iteration)}}</div></div>
+        <div><span class="label">Latest update</span><div class="value">${{escapeHtml(run.latest_update)}}</div></div>
+        <div><span class="label">Heartbeat freshness</span><div class="value">${{escapeHtml(heartbeat.age_seconds)}}s</div></div>
+        <div><span class="label">Diagnosis</span><div class="value">${{escapeHtml(formatDiagnosis(diagnosis, run.stop_reason)).replaceAll('\\n', '<br>')}}</div></div>
+      `;
+    }}
+
+    function nodeLabel(iteration) {{
+      return iteration.hypothesis || iteration.strategy_change_summary || `Iteration ${{iteration.iteration}}`;
+    }}
+
+    function resetSelectedPanel() {{
+      const detailLink = document.querySelector('#open-detail-link');
+      detailLink.href = '#';
+      detailLink.textContent = 'Open detail page';
+      document.querySelector('#hypothesis-diff').textContent = 'No iteration selected.';
+      document.querySelector('#strategy-diff').textContent = 'No strategy change yet.';
+      document.querySelector('#metric-breakdown').textContent = 'No metrics yet.';
+      document.querySelector('#decision-reasoning').textContent = 'No decision yet.';
+    }}
+
+    function renderTimeline(iterations) {{
+      const timeline = document.querySelector('#iteration-timeline');
+      if (!iterations.length) {{
+        timeline.innerHTML = '<div class="empty">Waiting for iterations…</div>';
+        selectedIteration = null;
+        resetSelectedPanel();
+        return;
+      }}
+      if (!selectedIteration || !iterations.some(item => item.iteration === selectedIteration)) {{
+        selectedIteration = iterations[iterations.length - 1].iteration;
+      }}
+      timeline.innerHTML = iterations.map(iteration => `
+        <button class="node ${{statusClass(iteration.status)}}" aria-selected="${{iteration.iteration === selectedIteration}}" data-iteration="${{escapeHtml(iteration.iteration)}}">
+          <div class="node-title"><span>#${{escapeHtml(iteration.iteration)}} · ${{escapeHtml(iteration.status)}}</span><span>${{escapeHtml(iteration.decision)}}</span></div>
+          <p>${{escapeHtml(nodeLabel(iteration))}}</p>
+          <div class="metric-row">
+            <span class="metric">drawdown<strong>${{escapeHtml(metric(iteration.metrics, 'drawdown'))}}</strong></span>
+            <span class="metric">turnover<strong>${{escapeHtml(metric(iteration.metrics, 'turnover'))}}</strong></span>
+            <span class="metric">deflated_sr<strong>${{escapeHtml(metric(iteration.metrics, 'deflated_sr'))}}</strong></span>
+            <span class="metric">baseline delta<strong>${{escapeHtml(metric(iteration.metrics, 'baseline_delta'))}}</strong></span>
+          </div>
+        </button>
+      `).join('');
+      timeline.querySelectorAll('.node').forEach(node => {{
+        node.addEventListener('click', () => {{
+          selectedIteration = Number(node.dataset.iteration);
+          renderTimeline(iterations);
+          renderSelected(iterations);
+        }});
+      }});
+    }}
+
+    function renderSelected(iterations) {{
+      const selected = iterations.find(item => item.iteration === selectedIteration) || iterations[iterations.length - 1];
+      if (!selected) return;
+      const analysis = selected.analysis || {{}};
+      const breakdown = selected.metric_breakdown || {{ current: selected.metrics || {{}}, comparisons: [] }};
+      const detailLink = document.querySelector('#open-detail-link');
+      detailLink.href = `/iterations/${{selected.iteration}}`;
+      detailLink.textContent = `Open iteration ${{selected.iteration}}`;
+      document.querySelector('#hypothesis-diff').textContent = text(analysis.hypothesis_diff || selected.hypothesis);
+      document.querySelector('#strategy-diff').textContent = text(analysis.strategy_diff || selected.strategy_change_summary);
+      document.querySelector('#metric-breakdown').textContent = formatMetricBreakdown(breakdown);
+      document.querySelector('#decision-reasoning').textContent = formatDecisionReasoning(selected);
+    }}
+
+    function formatMetricBreakdown(breakdown) {{
+      const lines = ['Current metrics:', JSON.stringify(breakdown.current || {{}}, null, 2), '', 'Comparisons:'];
+      (breakdown.comparisons || []).forEach(comparison => {{
+        lines.push(`${{comparison.label}} · ${{text(comparison.summary)}}`);
+      }});
+      return lines.join('\\n');
+    }}
+
+    function formatDecisionReasoning(iteration) {{
+      const reasons = iteration.decision_reasons || [];
+      const lines = [`Decision: ${{text(iteration.decision)}}`];
+      if (reasons.length) {{
+        lines.push('Reasons:');
+        reasons.forEach(reason => lines.push(`- ${{reason}}`));
+      }} else {{
+        lines.push('No decision reasons recorded yet.');
+      }}
+      const diagnosis = formatDiagnosis(iteration.diagnosis);
+      if (diagnosis !== '—') {{
+        lines.push('', 'Diagnosis:', diagnosis);
+      }}
+      return lines.join('\\n');
+    }}
+
+    function renderSupport(state) {{
+      const iterations = state.iterations || [];
+      const latest = iterations[iterations.length - 1] || {{}};
+      const logs = iterations.flatMap(iteration => iteration.logs || []).slice(-6).reverse();
+      document.querySelector('#recent-activity').innerHTML = logs.length
+        ? logs.map(log => `<p><strong>${{escapeHtml(log.updated_at)}}</strong><br>${{escapeHtml(text(log.excerpt).slice(0, 180))}}</p>`).join('')
+        : 'No logs yet.';
+      document.querySelector('#artifact-availability').textContent = latest.artifacts
+        ? Object.entries(latest.artifacts).map(([name, exists]) => `${{name}}: ${{exists ? 'yes' : 'no'}}`).join('\\n')
+        : 'No artifacts yet.';
+      document.querySelector('#performance-trend').textContent = (state.ledger.rows || [])
+        .map((row, index) => `#${{index + 1}} score=${{text(row.score)}} deflated_sr=${{text(row.deflated_sr)}} drawdown=${{text(row.drawdown)}}`)
+        .slice(-6)
+        .join('\\n') || 'No ledger data yet.';
+      document.querySelector('#decision-summary').textContent = iterations
+        .map(iteration => `#${{iteration.iteration}} ${{text(iteration.decision)}} — ${{(iteration.decision_reasons || []).join(', ') || 'no reason recorded'}}`)
+        .slice(-6)
+        .join('\\n') || 'No decisions yet.';
+    }}
+
+    async function loadDashboardState() {{
+      const response = await fetch('/api/state', {{ cache: 'no-store' }});
+      const state = await response.json();
+      renderHealth(state.run || {{}});
+      renderTimeline(state.iterations || []);
+      renderSelected(state.iterations || []);
+      renderSupport(state);
+      document.querySelector('#last-refresh').textContent = new Date().toLocaleTimeString();
+    }}
+
+    loadDashboardState().catch(error => {{
+      document.querySelector('#last-refresh').textContent = `Refresh failed: ${{error.message}}`;
+    }});
+    setInterval(loadDashboardState, {refresh_milliseconds});
+  </script>
+</body>
+</html>
+"""
+
+
+def render_iteration_detail_index(iteration_number: int, *, refresh_seconds: float = 3.0) -> str:
+    """Render a drill-down page for one iteration."""
+    refresh_milliseconds = max(1, int(refresh_seconds * 1000))
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Iteration {iteration_number} Detail · Quant Autoresearch</title>
+  <style>
+    :root {{
+      color-scheme: dark;
+      --bg: #090c10;
+      --panel: rgba(17, 23, 31, 0.86);
+      --panel-strong: rgba(25, 35, 46, 0.96);
+      --line: rgba(141, 232, 255, 0.22);
+      --ink: #e9f7ff;
+      --muted: #90a8b5;
+      --cyan: #56e4ff;
+      --lime: #c6ff5c;
+      --amber: #ffcc66;
+      --red: #ff6b7a;
+      --shadow: 0 22px 80px rgba(0, 0, 0, 0.45);
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      min-height: 100vh;
+      margin: 0;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at 18% 12%, rgba(86, 228, 255, 0.18), transparent 30rem),
+        radial-gradient(circle at 82% 18%, rgba(198, 255, 92, 0.10), transparent 28rem),
+        linear-gradient(135deg, #06080c 0%, #0d1218 54%, #11171f 100%);
+      font-family: "Avenir Next", "Gill Sans", "Trebuchet MS", sans-serif;
+      letter-spacing: 0.01em;
+    }}
+    main {{
+      width: min(1320px, calc(100vw - 40px));
+      margin: 0 auto;
+      padding: 32px 0 44px;
+    }}
+    a {{ color: var(--lime); text-decoration: none; }}
+    .masthead {{
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 24px;
+      margin-bottom: 20px;
+    }}
+    h1 {{
+      margin: 0;
+      font-family: "Copperplate", "Avenir Next", sans-serif;
+      font-size: clamp(2rem, 5vw, 4.6rem);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }}
+    .eyebrow, .label {{
+      color: var(--cyan);
+      font-size: 0.74rem;
+      font-weight: 800;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+    }}
+    .refresh {{
+      color: var(--muted);
+      text-align: right;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      font-size: 0.74rem;
+    }}
+    .summary {{
+      display: grid;
+      grid-template-columns: repeat(5, minmax(120px, 1fr));
+      gap: 1px;
+      margin-bottom: 18px;
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      overflow: hidden;
+      background: var(--line);
+      box-shadow: var(--shadow);
+    }}
+    .summary div {{
+      min-height: 94px;
+      padding: 16px;
+      background: var(--panel-strong);
+    }}
+    .value {{
+      margin-top: 8px;
+      font-size: clamp(1.05rem, 2vw, 1.6rem);
+      font-weight: 800;
+      word-break: break-word;
+    }}
+    .grid {{
+      display: grid;
+      grid-template-columns: minmax(380px, 1fr) minmax(320px, 0.75fr);
+      gap: 18px;
+    }}
+    .panel {{
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      background: var(--panel);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }}
+    .panel h2, .panel h3 {{
+      margin: 0;
+      padding: 18px 20px 12px;
+      font-size: 0.82rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--cyan);
+      border-bottom: 1px solid var(--line);
+    }}
+    .detail-section {{
+      padding: 18px 20px;
+      border-bottom: 1px solid var(--line);
+    }}
+    .detail-section:last-child {{ border-bottom: 0; }}
+    pre {{
+      white-space: pre-wrap;
+      margin: 8px 0 0;
+      font-family: "SFMono-Regular", "Menlo", monospace;
+      font-size: 0.84rem;
+      line-height: 1.5;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+      font-size: 0.88rem;
+    }}
+    th, td {{
+      padding: 10px 8px;
+      border-top: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }}
+    th {{ color: var(--muted); text-transform: uppercase; letter-spacing: 0.12em; }}
+    .muted {{ color: var(--muted); }}
+    @media (max-width: 980px) {{
+      .grid {{ grid-template-columns: 1fr; }}
+      .summary {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <header class="masthead">
+      <div>
+        <div class="eyebrow"><a href="/">← Back to monitor</a></div>
+        <h1>Iteration Detail</h1>
+      </div>
+      <div class="refresh">Live refresh · <span id="refresh-rate">{refresh_seconds:g}s</span><br><span id="last-refresh">Booting</span></div>
+    </header>
+
+    <section class="summary" aria-label="Iteration summary">
+      <div><span class="label">Iteration</span><div class="value">#{iteration_number}</div></div>
+      <div><span class="label">Status</span><div class="value" id="iteration-detail-status">Loading</div></div>
+      <div><span class="label">Decision</span><div class="value" id="iteration-detail-decision">—</div></div>
+      <div><span class="label">Score</span><div class="value" id="iteration-detail-score">—</div></div>
+      <div><span class="label">Baseline delta</span><div class="value" id="iteration-detail-baseline-delta">—</div></div>
+    </section>
+
+    <section class="grid">
+      <section class="panel">
+        <h2>Approved Reading Order</h2>
+        <div class="detail-section"><span class="label">Hypothesis diff</span><pre id="hypothesis-diff">Loading…</pre></div>
+        <div class="detail-section"><span class="label">Strategy diff</span><pre id="strategy-diff">Loading…</pre></div>
+        <div class="detail-section"><span class="label">Metric breakdown</span><pre id="metric-breakdown">vs previous iteration · vs current baseline · vs best iteration in current run</pre></div>
+        <div class="detail-section"><span class="label">Decision reasoning</span><pre id="decision-reasoning">Loading…</pre></div>
+      </section>
+
+      <aside>
+        <section class="panel">
+          <h3>Artifact References</h3>
+          <div class="detail-section" id="artifact-references">Loading artifacts…</div>
+        </section>
+        <section class="panel" style="margin-top:18px">
+          <h3>Log Excerpts</h3>
+          <div class="detail-section" id="log-excerpts">Loading logs…</div>
+        </section>
+      </aside>
+    </section>
+  </main>
+  <script>
+    const iterationNumber = {iteration_number};
+    const text = value => value === null || value === undefined || value === "" ? "—" : String(value);
+    const escapeHtml = value => text(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+    const formatDiagnosis = (diagnosis, fallback = null) => {{
+      const lines = [];
+      if (diagnosis && diagnosis.reason) {{
+        lines.push(text(diagnosis.reason));
+      }} else if (fallback) {{
+        lines.push(text(fallback));
+      }}
+      (diagnosis && diagnosis.details ? diagnosis.details : []).forEach(detail => lines.push(`- ${{text(detail)}}`));
+      if (diagnosis && diagnosis.time_since_heartbeat_seconds !== undefined && diagnosis.time_since_heartbeat_seconds !== null) {{
+        lines.push(`heartbeat_age=${{text(diagnosis.time_since_heartbeat_seconds)}}s`);
+      }}
+      if (diagnosis && diagnosis.missing_artifacts && diagnosis.missing_artifacts.length) {{
+        lines.push(`missing=${{diagnosis.missing_artifacts.join(', ')}}`);
+      }}
+      return lines.join('\\n') || '—';
+    }};
+    const formatDeltas = deltas => Object.entries(deltas || {{}})
+      .map(([key, value]) => `${{key}}: ${{Number(value).toLocaleString(undefined, {{ maximumSignificantDigits: 6, signDisplay: 'always' }})}}`)
+      .join(', ') || 'No comparable metrics.';
+
+    function formatMetricBreakdown(breakdown) {{
+      const lines = ['Current metrics:', JSON.stringify((breakdown && breakdown.current) || {{}}, null, 2), '', 'Comparisons:'];
+      ((breakdown && breakdown.comparisons) || []).forEach(comparison => {{
+        lines.push(`${{comparison.label}}`);
+        lines.push(`  reference: ${{text(comparison.reference_iteration || comparison.reference_metric)}}`);
+        lines.push(`  deltas: ${{formatDeltas(comparison.deltas)}}`);
+        lines.push(`  summary: ${{text(comparison.summary)}}`);
+      }});
+      return lines.join('\\n');
+    }}
+
+    function formatDecisionReasoning(iteration) {{
+      const reasons = iteration.decision_reasons || [];
+      const lines = [`Decision: ${{text(iteration.decision)}}`];
+      if (reasons.length) {{
+        lines.push('Reasons:');
+        reasons.forEach(reason => lines.push(`- ${{reason}}`));
+      }} else {{
+        lines.push('No decision reasons recorded yet.');
+      }}
+      const diagnosis = formatDiagnosis(iteration.diagnosis);
+      if (diagnosis !== '—') {{
+        lines.push('', 'Diagnosis:', diagnosis);
+      }}
+      return lines.join('\\n');
+    }}
+
+    function renderArtifacts(references) {{
+      if (!references || !references.length) return 'No artifact references yet.';
+      return `<table><thead><tr><th>Name</th><th>Status</th><th>Path</th></tr></thead><tbody>${{references.map(item => `
+        <tr><td>${{escapeHtml(item.name)}}</td><td>${{item.exists ? 'present' : 'missing'}}</td><td class="muted">${{escapeHtml(item.path)}}</td></tr>
+      `).join('')}}</tbody></table>`;
+    }}
+
+    function renderLogs(logs) {{
+      if (!logs || !logs.length) return 'No logs yet.';
+      return logs.map(log => `<p><strong>${{escapeHtml(log.updated_at)}}</strong><br><span class="muted">${{escapeHtml(log.path)}}</span></p><pre>${{escapeHtml(log.excerpt)}}</pre>`).join('');
+    }}
+
+    function resetMissingIterationDetail() {{
+      document.querySelector('#iteration-detail-status').textContent = 'Missing';
+      document.querySelector('#iteration-detail-decision').textContent = '—';
+      document.querySelector('#iteration-detail-score').textContent = '—';
+      document.querySelector('#iteration-detail-baseline-delta').textContent = '—';
+      document.querySelector('#hypothesis-diff').textContent = 'No iteration selected.';
+      document.querySelector('#strategy-diff').textContent = 'No strategy change yet.';
+      document.querySelector('#metric-breakdown').textContent = 'No metrics yet.';
+      document.querySelector('#decision-reasoning').textContent = 'No decision yet.';
+      document.querySelector('#artifact-references').innerHTML = 'No artifact references yet.';
+      document.querySelector('#log-excerpts').innerHTML = 'No logs yet.';
+    }}
+
+    function renderIterationDetail(state) {{
+      const selected = (state.iterations || []).find(item => item.iteration === iterationNumber);
+      if (!selected) {{
+        resetMissingIterationDetail();
+        document.querySelector('#last-refresh').textContent = new Date().toLocaleTimeString();
+        return;
+      }}
+      const analysis = selected.analysis || {{}};
+      const breakdown = selected.metric_breakdown || {{ current: selected.metrics || {{}}, comparisons: [] }};
+      document.querySelector('#iteration-detail-status').textContent = text(selected.status);
+      document.querySelector('#iteration-detail-decision').textContent = text(selected.decision);
+      document.querySelector('#iteration-detail-score').textContent = text(selected.metrics && selected.metrics.score);
+      document.querySelector('#iteration-detail-baseline-delta').textContent = text(selected.metrics && selected.metrics.baseline_delta);
+      document.querySelector('#hypothesis-diff').textContent = text(analysis.hypothesis_diff || selected.hypothesis);
+      document.querySelector('#strategy-diff').textContent = text(analysis.strategy_diff || selected.strategy_change_summary);
+      document.querySelector('#metric-breakdown').textContent = formatMetricBreakdown(breakdown);
+      document.querySelector('#decision-reasoning').textContent = formatDecisionReasoning(selected);
+      document.querySelector('#artifact-references').innerHTML = renderArtifacts(selected.artifact_references || []);
+      document.querySelector('#log-excerpts').innerHTML = renderLogs(selected.logs || []);
+      document.querySelector('#last-refresh').textContent = new Date().toLocaleTimeString();
+    }}
+
+    async function loadIterationDetail() {{
+      const response = await fetch('/api/state', {{ cache: 'no-store' }});
+      renderIterationDetail(await response.json());
+    }}
+
+    loadIterationDetail().catch(error => {{
+      document.querySelector('#last-refresh').textContent = `Refresh failed: ${{error.message}}`;
+    }});
+    setInterval(loadIterationDetail, {refresh_milliseconds});
+  </script>
+</body>
+</html>
+"""
+
+
+def _iteration_number_from_path(path: str) -> int | None:
+    prefix = "/iterations/"
+    if not path.startswith(prefix):
+        return None
+    value = path.removeprefix(prefix).strip("/")
+    if not value.isdigit():
+        return None
+    return int(value)
+
+
+def make_dashboard_handler(repo_root: str | Path, *, refresh_seconds: float = 3.0) -> type[BaseHTTPRequestHandler]:
+    """Build a request handler bound to a repo root."""
+    resolved_root = Path(repo_root)
+
+    class DashboardRequestHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            path = urlparse(self.path).path
+            if path in {"/", "/index.html"}:
+                self._send_text(
+                    render_dashboard_index(refresh_seconds=refresh_seconds),
+                    content_type="text/html; charset=utf-8",
+                )
+                return
+            iteration_number = _iteration_number_from_path(path)
+            if iteration_number is not None:
+                self._send_text(
+                    render_iteration_detail_index(iteration_number, refresh_seconds=refresh_seconds),
+                    content_type="text/html; charset=utf-8",
+                )
+                return
+            if path == "/api/state":
+                self._send_json(observe_dashboard_state(resolved_root))
+                return
+            self.send_error(HTTPStatus.NOT_FOUND, "Dashboard resource not found")
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+        def _send_text(self, payload: str, *, content_type: str) -> None:
+            encoded = payload.encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(encoded)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def _send_json(self, payload: dict[str, Any]) -> None:
+            self._send_text(
+                json.dumps(payload, ensure_ascii=False),
+                content_type="application/json; charset=utf-8",
+            )
+
+    return DashboardRequestHandler
+
+
+def serve_dashboard(
+    *,
+    repo_root: str | Path,
+    host: str = "127.0.0.1",
+    port: int = 8765,
+    refresh_seconds: float = 3.0,
+) -> None:
+    """Serve the read-only dashboard until interrupted."""
+    handler = make_dashboard_handler(repo_root, refresh_seconds=refresh_seconds)
+    server = ThreadingHTTPServer((host, port), handler)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()

--- a/tests/integration/test_dashboard_validation.py
+++ b/tests/integration/test_dashboard_validation.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from urllib.request import urlopen
+
+from src.dashboard.server import make_dashboard_handler
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _touch_at(path: Path, timestamp: float, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    os.utime(path, (timestamp, timestamp))
+
+
+def _write_results_tsv(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\t".join(
+            [
+                "commit",
+                "score",
+                "naive_sharpe",
+                "deflated_sr",
+                "sortino",
+                "calmar",
+                "drawdown",
+                "max_dd_days",
+                "trades",
+                "win_rate",
+                "profit_factor",
+                "avg_win",
+                "avg_loss",
+                "baseline_sharpe",
+                "nw_bias",
+                "status",
+                "description",
+            ]
+        )
+        + "\n"
+        + "\n".join(
+            [
+                "\t".join(
+                    [
+                        "iter-1",
+                        "0.720000",
+                        "0.800000",
+                        "0.610000",
+                        "1.100000",
+                        "0.900000",
+                        "-0.080000",
+                        "12",
+                        "34",
+                        "0.590000",
+                        "1.400000",
+                        "0.020000",
+                        "-0.010000",
+                        "0.500000",
+                        "0.070000",
+                        "kept",
+                        "first round",
+                    ]
+                ),
+                "\t".join(
+                    [
+                        "iter-2",
+                        "0.810000",
+                        "0.900000",
+                        "0.690000",
+                        "1.200000",
+                        "1.000000",
+                        "-0.060000",
+                        "10",
+                        "24",
+                        "0.630000",
+                        "1.600000",
+                        "0.025000",
+                        "-0.008000",
+                        "0.500000",
+                        "0.050000",
+                        "kept",
+                        "second round",
+                    ]
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _create_representative_dashboard_repo(
+    repo_root: Path,
+    *,
+    now: datetime | None = None,
+) -> None:
+    now = now or datetime.now(timezone.utc)
+    run_root = repo_root / "experiments" / "iterations" / "run-verify"
+    first_dir = run_root / "iteration-0001"
+    second_dir = run_root / "iteration-0002"
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-verify",
+            "status": "running",
+            "current_iteration": 2,
+            "active_iteration": None,
+            "last_completed_iteration": 2,
+            "best_score": 0.81,
+            "best_iteration": 2,
+            "updated_at": now.isoformat(),
+        },
+    )
+    _write_json(
+        first_dir / "iteration_record.json",
+        {
+            "run_id": "run-verify",
+            "iteration_number": 1,
+            "artifact_status": "completed",
+            "execution_mode": "live",
+            "summary": {
+                "hypothesis": "Reduce turnover with a no-trade band",
+                "strategy_change_summary": "Added a bounded entry threshold",
+                "files_touched": ["src/strategies/active_strategy.py"],
+            },
+            "decision": "keep",
+            "decision_reason": ["score_above_baseline_and_previous_best"],
+            "artifact_paths": {
+                "decision": str(first_dir / "decision.json"),
+                "context_json": str(first_dir / "context.json"),
+            },
+        },
+    )
+    _write_json(
+        first_dir / "decision.json",
+        {
+            "decision": "keep",
+            "reasons": ["score_above_baseline_and_previous_best"],
+            "score": 0.72,
+            "baseline_sharpe": 0.5,
+            "deflated_sr": 0.61,
+        },
+    )
+    _write_json(first_dir / "context.json", {"iteration": 1})
+
+    _write_json(
+        second_dir / "iteration_record.json",
+        {
+            "run_id": "run-verify",
+            "iteration_number": 2,
+            "artifact_status": "completed",
+            "execution_mode": "live",
+            "summary": {
+                "hypothesis": "Tighten the no-trade band during low-volatility windows",
+                "strategy_change_summary": "Reduced turnover by gating entries on realized volatility",
+                "files_touched": ["src/strategies/active_strategy.py", "config/strategy.json"],
+            },
+            "decision": "keep",
+            "decision_reason": ["score_above_previous_iteration", "turnover_reduced"],
+            "artifact_paths": {
+                "decision": str(second_dir / "decision.json"),
+                "context_json": str(second_dir / "context.json"),
+                "experiment_note_draft": str(second_dir / "experiment_note_draft.md"),
+            },
+        },
+    )
+    _write_json(
+        second_dir / "decision.json",
+        {
+            "decision": "keep",
+            "reasons": ["score_above_previous_iteration", "turnover_reduced"],
+            "score": 0.81,
+            "baseline_sharpe": 0.5,
+            "deflated_sr": 0.69,
+        },
+    )
+    _write_json(second_dir / "context.json", {"iteration": 2})
+    (second_dir / "experiment_note_draft.md").write_text("# Draft\n", encoding="utf-8")
+    _touch_at(first_dir / "claude.stdout.log", now.timestamp() - 60, "round 1 complete\n")
+    _touch_at(second_dir / "claude.stdout.log", now.timestamp() - 3, "round 2 complete\n")
+    _write_results_tsv(repo_root / "experiments" / "results.tsv")
+
+
+def test_dashboard_validates_representative_artifact_tree_within_ten_seconds(tmp_path):
+    repo_root = tmp_path
+    fixture_now = datetime.now(timezone.utc)
+    _create_representative_dashboard_repo(repo_root, now=fixture_now)
+
+    handler = make_dashboard_handler(repo_root, refresh_seconds=0.5)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        host, port = server.server_address
+
+        start = time.monotonic()
+        with urlopen(f"http://{host}:{port}/", timeout=10) as response:
+            home_html = response.read().decode("utf-8")
+        home_elapsed = time.monotonic() - start
+
+        start = time.monotonic()
+        with urlopen(f"http://{host}:{port}/iterations/2", timeout=10) as response:
+            detail_html = response.read().decode("utf-8")
+        detail_elapsed = time.monotonic() - start
+
+        with urlopen(f"http://{host}:{port}/api/state", timeout=10) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        assert home_elapsed < 10, f"home page exceeded 10s: {home_elapsed:.2f}s"
+        assert detail_elapsed < 10, f"detail page exceeded 10s: {detail_elapsed:.2f}s"
+        assert "Research Monitor" in home_html
+        assert "Run Health Strip" in home_html
+        assert "Iteration Detail" in detail_html
+
+        assert payload["run"]["run_id"] == "run-verify"
+        assert payload["run"]["status"] == "Healthy"
+        assert payload["run"]["diagnosis"] is None
+        assert payload["run"]["heartbeat"]["source_role"] in {"artifact", "log"}
+        assert payload["run"]["heartbeat"]["age_seconds"] < 10
+        assert payload["iterations"][-1]["decision"] == "keep"
+        assert payload["iterations"][-1]["status"] == "Kept"
+        assert payload["iterations"][-1]["analysis"]["hypothesis_diff"].startswith(
+            "Previous: Reduce turnover with a no-trade band"
+        )
+        assert payload["iterations"][-1]["decision_reasons"] == [
+            "score_above_previous_iteration",
+            "turnover_reduced",
+        ]
+        assert payload["iterations"][-1]["metric_breakdown"]["comparisons"][1]["label"] == "vs current baseline"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -135,6 +135,46 @@ class TestCommandRegistration:
         assert result.exit_code == 0
         assert "analyze" in result.stdout
 
+    def test_dashboard_command_exists(self):
+        """Verify dashboard is registered as a read-only local monitor."""
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "dashboard" in result.stdout
+
+        result = runner.invoke(app, ["dashboard", "--help"])
+        assert result.exit_code == 0
+        assert "--host" in result.stdout
+        assert "--port" in result.stdout
+        assert "--repo-root" in result.stdout
+        assert "--refresh-seconds" in result.stdout
+
+    @patch("cli.serve_dashboard")
+    def test_dashboard_invokes_read_only_server(self, mock_serve_dashboard, tmp_path):
+        """Verify dashboard command launches the read-only local server."""
+        result = runner.invoke(
+            app,
+            [
+                "dashboard",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "9876",
+                "--repo-root",
+                str(tmp_path),
+                "--refresh-seconds",
+                "2.5",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Dashboard listening on http://127.0.0.1:9876" in result.stdout
+        mock_serve_dashboard.assert_called_once_with(
+            repo_root=tmp_path,
+            host="127.0.0.1",
+            port=9876,
+            refresh_seconds=2.5,
+        )
+
 
 class TestBacktestCommandBehavior:
     """Tests for backtest command behavior with mocked dependencies."""

--- a/tests/unit/test_dashboard_observer.py
+++ b/tests/unit/test_dashboard_observer.py
@@ -1,0 +1,715 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.dashboard.observer import observe_dashboard_state
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _touch_at(path: Path, timestamp: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(path.read_text(encoding="utf-8") if path.exists() else "", encoding="utf-8")
+    path.touch()
+    path.chmod(0o644)
+    import os
+
+    os.utime(path, (timestamp, timestamp))
+
+
+def _write_results_tsv(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\t".join(
+            [
+                "commit",
+                "score",
+                "naive_sharpe",
+                "deflated_sr",
+                "sortino",
+                "calmar",
+                "drawdown",
+                "max_dd_days",
+                "trades",
+                "win_rate",
+                "profit_factor",
+                "avg_win",
+                "avg_loss",
+                "baseline_sharpe",
+                "nw_bias",
+                "status",
+                "description",
+            ]
+        )
+        + "\n"
+        + "\t".join(
+            [
+                "working",
+                "0.720000",
+                "0.800000",
+                "0.610000",
+                "1.100000",
+                "0.900000",
+                "-0.080000",
+                "12",
+                "34",
+                "0.590000",
+                "1.400000",
+                "0.020000",
+                "-0.010000",
+                "0.500000",
+                "0.070000",
+                "pending",
+                "first round",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_multirow_results_tsv(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\t".join(
+            [
+                "iteration",
+                "commit",
+                "score",
+                "naive_sharpe",
+                "deflated_sr",
+                "sortino",
+                "calmar",
+                "drawdown",
+                "max_dd_days",
+                "trades",
+                "win_rate",
+                "profit_factor",
+                "avg_win",
+                "avg_loss",
+                "baseline_sharpe",
+                "nw_bias",
+                "status",
+                "description",
+            ]
+        )
+        + "\n"
+        + "\n".join(
+            [
+                "\t".join(
+                    [
+                        "1",
+                        "first",
+                        "0.720000",
+                        "0.800000",
+                        "0.610000",
+                        "1.100000",
+                        "0.900000",
+                        "-0.080000",
+                        "12",
+                        "34",
+                        "0.590000",
+                        "1.400000",
+                        "0.020000",
+                        "-0.010000",
+                        "0.500000",
+                        "0.070000",
+                        "kept",
+                        "first round",
+                    ]
+                ),
+                "\t".join(
+                    [
+                        "2",
+                        "second",
+                        "0.810000",
+                        "0.900000",
+                        "0.690000",
+                        "1.200000",
+                        "1.000000",
+                        "-0.060000",
+                        "10",
+                        "24",
+                        "0.630000",
+                        "1.600000",
+                        "0.025000",
+                        "-0.008000",
+                        "0.500000",
+                        "0.050000",
+                        "kept",
+                        "second round",
+                    ]
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_ambiguous_multirow_results_tsv(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\t".join(
+            [
+                "commit",
+                "score",
+                "naive_sharpe",
+                "deflated_sr",
+                "sortino",
+                "calmar",
+                "drawdown",
+                "max_dd_days",
+                "trades",
+                "win_rate",
+                "profit_factor",
+                "avg_win",
+                "avg_loss",
+                "baseline_sharpe",
+                "nw_bias",
+                "status",
+                "description",
+            ]
+        )
+        + "\n"
+        + "\n".join(
+            [
+                "\t".join(
+                    [
+                        "unkeyed-first",
+                        "0.720000",
+                        "0.800000",
+                        "0.610000",
+                        "1.100000",
+                        "0.900000",
+                        "-0.080000",
+                        "12",
+                        "34",
+                        "0.590000",
+                        "1.400000",
+                        "0.020000",
+                        "-0.010000",
+                        "0.500000",
+                        "0.070000",
+                        "kept",
+                        "first round",
+                    ]
+                ),
+                "\t".join(
+                    [
+                        "unkeyed-second",
+                        "0.810000",
+                        "0.900000",
+                        "0.690000",
+                        "1.200000",
+                        "1.000000",
+                        "-0.060000",
+                        "10",
+                        "24",
+                        "0.630000",
+                        "1.600000",
+                        "0.025000",
+                        "-0.008000",
+                        "0.500000",
+                        "0.050000",
+                        "kept",
+                        "second round",
+                    ]
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_observe_dashboard_state_ingests_sources_and_uses_log_heartbeat(tmp_path):
+    now = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    repo_root = tmp_path
+    run_root = repo_root / "experiments" / "iterations" / "run-001"
+    iteration_dir = run_root / "iteration-0001"
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-001",
+            "status": "running",
+            "current_iteration": 1,
+            "active_iteration": 2,
+            "iteration_budget": 5,
+            "best_score": 0.72,
+            "best_iteration": 1,
+            "updated_at": "2026-04-19T11:59:00+00:00",
+        },
+    )
+    _write_json(
+        iteration_dir / "iteration_record.json",
+        {
+            "run_id": "run-001",
+            "iteration_number": 1,
+            "artifact_status": "completed",
+            "execution_mode": "live",
+            "summary": {
+                "hypothesis": "Reduce turnover with a no-trade band",
+                "strategy_change_summary": "Added a bounded entry threshold",
+                "files_touched": ["src/strategies/active_strategy.py"],
+            },
+            "decision": "keep",
+            "decision_reason": ["score_above_baseline_and_previous_best"],
+            "artifact_paths": {
+                "claude_stdout": str(iteration_dir / "claude.stdout.log"),
+                "backtest_stdout": str(iteration_dir / "backtest.stdout.log"),
+                "decision": str(iteration_dir / "decision.json"),
+            },
+        },
+    )
+    _write_json(
+        iteration_dir / "decision.json",
+        {
+            "decision": "keep",
+            "reasons": ["score_above_baseline_and_previous_best"],
+            "score": 0.72,
+            "baseline_sharpe": 0.5,
+            "deflated_sr": 0.61,
+        },
+    )
+    (iteration_dir / "claude.stdout.log").write_text("fresh heartbeat\n", encoding="utf-8")
+    _touch_at(iteration_dir / "claude.stdout.log", now.timestamp() - 4)
+    (iteration_dir / "backtest.stdout.log").write_text("SCORE: 0.72\n", encoding="utf-8")
+    _touch_at(iteration_dir / "backtest.stdout.log", now.timestamp() - 30)
+    _write_results_tsv(repo_root / "experiments" / "results.tsv")
+
+    dashboard = observe_dashboard_state(repo_root, now=now, stale_after_seconds=60)
+
+    assert dashboard["run"]["status"] == "Busy"
+    assert dashboard["run"]["heartbeat"]["source_role"] == "log"
+    assert dashboard["run"]["heartbeat"]["age_seconds"] == pytest.approx(4)
+    assert dashboard["run"]["active_iteration"] == 2
+    assert dashboard["iterations"][0]["status"] == "Kept"
+    assert dashboard["iterations"][0]["hypothesis"] == "Reduce turnover with a no-trade band"
+    assert dashboard["iterations"][0]["metrics"]["score"] == pytest.approx(0.72)
+    assert dashboard["iterations"][0]["metrics"]["baseline_delta"] == pytest.approx(0.22)
+    assert dashboard["ledger"]["rows"][0]["deflated_sr"] == pytest.approx(0.61)
+
+
+def test_observe_dashboard_state_marks_stalled_when_heartbeat_is_stale(tmp_path):
+    now = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    repo_root = tmp_path
+    iteration_dir = repo_root / "experiments" / "iterations" / "run-stale" / "iteration-0002"
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-stale",
+            "status": "running",
+            "current_iteration": 1,
+            "active_iteration": 2,
+            "iteration_budget": 3,
+            "updated_at": "2026-04-19T11:00:00+00:00",
+        },
+    )
+    (iteration_dir / "claude.stdout.log").parent.mkdir(parents=True, exist_ok=True)
+    (iteration_dir / "claude.stdout.log").write_text("old heartbeat\n", encoding="utf-8")
+    _touch_at(iteration_dir / "claude.stdout.log", now.timestamp() - 7200)
+
+    dashboard = observe_dashboard_state(repo_root, now=now, stale_after_seconds=300)
+
+    assert dashboard["run"]["status"] == "Stalled"
+    assert dashboard["run"]["diagnosis"]["reason"] == "heartbeat_stale"
+    assert dashboard["run"]["diagnosis"]["affected_iteration"] == 2
+    assert dashboard["run"]["heartbeat"]["source_role"] == "state"
+    assert dashboard["run"]["heartbeat"]["age_seconds"] == pytest.approx(3600)
+
+
+def test_observe_dashboard_state_explains_blocked_run_and_failed_iteration(tmp_path):
+    now = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    repo_root = tmp_path
+    iteration_dir = repo_root / "experiments" / "iterations" / "run-blocked" / "iteration-0001"
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-blocked",
+            "status": "blocked",
+            "current_iteration": 0,
+            "active_iteration": None,
+            "iteration_budget": 3,
+            "stop_reason": "claude_rate_limited",
+            "last_error": "claude_iteration_rate_limited; API limit",
+            "last_decision": {
+                "decision": "failed",
+                "reasons": ["claude_iteration_rate_limited", "API limit"],
+            },
+            "updated_at": "2026-04-19T11:59:30+00:00",
+        },
+    )
+    _write_json(
+        iteration_dir / "iteration_record.json",
+        {
+            "run_id": "run-blocked",
+            "iteration_number": 1,
+            "artifact_status": "failed",
+            "execution_mode": "live",
+            "summary": {
+                "hypothesis": "Try rate-limited iteration",
+                "strategy_change_summary": "No change landed",
+                "files_touched": [],
+            },
+            "decision": "failed",
+            "decision_reason": ["claude_iteration_rate_limited", "API limit"],
+            "artifact_paths": {},
+        },
+    )
+
+    dashboard = observe_dashboard_state(repo_root, now=now, stale_after_seconds=300)
+
+    assert dashboard["run"]["status"] == "Blocked"
+    assert dashboard["run"]["diagnosis"]["reason"] == "claude_rate_limited"
+    assert dashboard["run"]["diagnosis"]["details"] == ["claude_iteration_rate_limited", "API limit"]
+    assert dashboard["iterations"][0]["status"] == "Failed"
+    assert dashboard["iterations"][0]["decision_reasons"] == ["claude_iteration_rate_limited", "API limit"]
+
+
+def test_observe_dashboard_state_marks_waiting_and_completed_runs_with_diagnosis(tmp_path):
+    waiting_dashboard = observe_dashboard_state(tmp_path, now=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc))
+
+    assert waiting_dashboard["run"]["status"] == "Waiting"
+    assert waiting_dashboard["run"]["diagnosis"]["reason"] == "awaiting_state"
+
+    _write_json(
+        tmp_path / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-complete",
+            "status": "completed",
+            "current_iteration": 3,
+            "active_iteration": None,
+            "last_completed_iteration": 3,
+            "stop_reason": "iteration_budget_reached",
+            "updated_at": "2026-04-19T11:59:30+00:00",
+        },
+    )
+
+    completed_dashboard = observe_dashboard_state(
+        tmp_path,
+        now=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert completed_dashboard["run"]["status"] == "Completed"
+    assert completed_dashboard["run"]["diagnosis"]["reason"] == "iteration_budget_reached"
+    assert completed_dashboard["run"]["diagnosis"]["details"] == ["last_completed_iteration=3"]
+
+
+def test_observe_dashboard_state_tracks_partial_and_pending_iteration_diagnosis(tmp_path):
+    now = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    repo_root = tmp_path
+    partial_dir = repo_root / "experiments" / "iterations" / "run-partial" / "iteration-0001"
+    pending_dir = repo_root / "experiments" / "iterations" / "run-partial" / "iteration-0002"
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-partial",
+            "status": "running",
+            "current_iteration": 2,
+            "active_iteration": 2,
+            "updated_at": "2026-04-19T11:59:30+00:00",
+        },
+    )
+    (partial_dir / "claude.stdout.log").parent.mkdir(parents=True, exist_ok=True)
+    (partial_dir / "claude.stdout.log").write_text("iteration still working\n", encoding="utf-8")
+    _touch_at(partial_dir / "claude.stdout.log", now.timestamp() - 5)
+    (partial_dir / "context.json").write_text("{}", encoding="utf-8")
+
+    _write_json(
+        pending_dir / "iteration_record.json",
+        {
+            "run_id": "run-partial",
+            "iteration_number": 2,
+            "artifact_status": "completed",
+            "execution_mode": "live",
+            "summary": {
+                "hypothesis": "Need evaluator decision",
+                "strategy_change_summary": "Candidate change landed",
+                "files_touched": ["src/strategies/active_strategy.py"],
+            },
+            "evaluation_summary": {"score": 0.55, "baseline_sharpe": 0.50},
+            "artifact_paths": {
+                "context_json": str(pending_dir / "context.json"),
+            },
+        },
+    )
+    (pending_dir / "context.json").write_text("{}", encoding="utf-8")
+
+    dashboard = observe_dashboard_state(repo_root, now=now, stale_after_seconds=60)
+    partial = dashboard["iterations"][0]
+    pending = dashboard["iterations"][1]
+
+    assert partial["status"] == "In Progress"
+    assert partial["diagnosis"]["reason"] == "artifacts_pending"
+    assert "decision" in partial["diagnosis"]["missing_artifacts"]
+    assert "iteration_record" in partial["diagnosis"]["missing_artifacts"]
+
+    assert pending["status"] == "Decision Pending"
+    assert pending["diagnosis"]["reason"] == "decision_pending"
+    assert pending["diagnosis"]["details"] == ["Awaiting decision artifact or final keep/revert outcome."]
+
+
+def test_observe_dashboard_state_adds_iteration_analysis_comparisons(tmp_path):
+    now = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    repo_root = tmp_path
+    first_dir = repo_root / "experiments" / "iterations" / "run-compare" / "iteration-0001"
+    second_dir = repo_root / "experiments" / "iterations" / "run-compare" / "iteration-0002"
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-compare",
+            "status": "running",
+            "current_iteration": 2,
+            "active_iteration": None,
+            "best_score": 0.81,
+            "best_iteration": 2,
+            "updated_at": "2026-04-19T11:59:30+00:00",
+        },
+    )
+    _write_json(
+        first_dir / "iteration_record.json",
+        {
+            "run_id": "run-compare",
+            "iteration_number": 1,
+            "artifact_status": "completed",
+            "summary": {
+                "hypothesis": "Reduce turnover with a no-trade band",
+                "strategy_change_summary": "Added a bounded entry threshold",
+                "files_touched": ["src/strategies/active_strategy.py"],
+            },
+            "decision": "keep",
+            "decision_reason": ["score_above_baseline_and_previous_best"],
+        },
+    )
+    _write_json(
+        second_dir / "iteration_record.json",
+        {
+            "run_id": "run-compare",
+            "iteration_number": 2,
+            "artifact_status": "completed",
+            "summary": {
+                "hypothesis": "Tighten the no-trade band during low-volatility windows",
+                "strategy_change_summary": "Reduced turnover by gating entries on realized volatility",
+                "files_touched": ["src/strategies/active_strategy.py", "config/strategy.json"],
+            },
+            "decision": "keep",
+            "decision_reason": ["score_above_previous_iteration", "turnover_reduced"],
+            "artifact_paths": {
+                "context_json": str(second_dir / "context.json"),
+                "backtest_stdout": str(second_dir / "backtest.stdout.log"),
+            },
+        },
+    )
+    (second_dir / "context.json").write_text("{}", encoding="utf-8")
+    (second_dir / "backtest.stdout.log").write_text("SCORE: 0.81\n", encoding="utf-8")
+    _write_multirow_results_tsv(repo_root / "experiments" / "results.tsv")
+
+    dashboard = observe_dashboard_state(repo_root, now=now, stale_after_seconds=60)
+    second = dashboard["iterations"][1]
+
+    assert "Previous: Reduce turnover with a no-trade band" in second["analysis"]["hypothesis_diff"]
+    assert "Current: Tighten the no-trade band during low-volatility windows" in second["analysis"]["hypothesis_diff"]
+    assert "config/strategy.json" in second["analysis"]["strategy_diff"]
+    assert second["artifact_references"][0]["name"] == "context_json"
+    assert [comparison["label"] for comparison in second["metric_breakdown"]["comparisons"]] == [
+        "vs previous iteration",
+        "vs current baseline",
+        "vs best iteration in current run",
+    ]
+    assert second["metric_breakdown"]["comparisons"][0]["deltas"]["score"] == pytest.approx(0.09)
+    assert second["metric_breakdown"]["comparisons"][1]["deltas"]["score"] == pytest.approx(0.31)
+    assert second["metric_breakdown"]["comparisons"][2]["reference_iteration"] == 2
+
+
+def test_observe_dashboard_state_resolves_repo_relative_artifact_paths(tmp_path):
+    repo_root = tmp_path
+    iteration_dir = repo_root / "experiments" / "iterations" / "run-relative" / "iteration-0001"
+    repo_relative_context = Path("experiments/iterations/run-relative/iteration-0001/context.json")
+    repo_relative_report = Path("experiments/reports/run-relative-summary.md")
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-relative",
+            "status": "running",
+            "current_iteration": 1,
+            "active_iteration": 1,
+            "updated_at": "2026-04-19T11:59:30+00:00",
+        },
+    )
+    _write_json(
+        iteration_dir / "iteration_record.json",
+        {
+            "run_id": "run-relative",
+            "iteration_number": 1,
+            "artifact_status": "completed",
+            "decision": "keep",
+            "artifact_paths": {
+                "context_json": str(repo_relative_context),
+                "summary_report": str(repo_relative_report),
+            },
+        },
+    )
+    _write_json(repo_root / repo_relative_context, {"iteration": 1})
+    (repo_root / repo_relative_report).parent.mkdir(parents=True, exist_ok=True)
+    (repo_root / repo_relative_report).write_text("# Summary\n", encoding="utf-8")
+
+    dashboard = observe_dashboard_state(
+        repo_root,
+        now=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+        stale_after_seconds=60,
+    )
+
+    references = {item["name"]: item for item in dashboard["iterations"][0]["artifact_references"]}
+    assert references["context_json"]["path"] == str(repo_root / repo_relative_context)
+    assert references["context_json"]["exists"] is True
+    assert references["summary_report"]["path"] == str(repo_root / repo_relative_report)
+    assert references["summary_report"]["exists"] is True
+
+
+def test_observe_dashboard_state_withholds_ambiguous_ledger_metrics(tmp_path):
+    repo_root = tmp_path
+    first_dir = repo_root / "experiments" / "iterations" / "run-ambiguous" / "iteration-0001"
+    second_dir = repo_root / "experiments" / "iterations" / "run-ambiguous" / "iteration-0002"
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-ambiguous",
+            "status": "running",
+            "current_iteration": 2,
+            "active_iteration": None,
+            "updated_at": "2026-04-19T11:59:30+00:00",
+        },
+    )
+    for iteration_number, iteration_dir in ((1, first_dir), (2, second_dir)):
+        _write_json(
+            iteration_dir / "iteration_record.json",
+            {
+                "run_id": "run-ambiguous",
+                "iteration_number": iteration_number,
+                "artifact_status": "completed",
+                "decision": "keep",
+            },
+        )
+    _write_ambiguous_multirow_results_tsv(repo_root / "experiments" / "results.tsv")
+
+    dashboard = observe_dashboard_state(
+        repo_root,
+        now=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+        stale_after_seconds=60,
+    )
+
+    assert len(dashboard["ledger"]["rows"]) == 2
+    assert "score" not in dashboard["iterations"][0]["metrics"]
+    assert "score" not in dashboard["iterations"][1]["metrics"]
+
+
+def test_observe_dashboard_state_withholds_single_unkeyed_ledger_row(tmp_path):
+    repo_root = tmp_path
+    iteration_dir = repo_root / "experiments" / "iterations" / "run-single-ledger" / "iteration-0001"
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-single-ledger",
+            "status": "running",
+            "current_iteration": 1,
+            "active_iteration": None,
+            "updated_at": "2026-04-19T11:59:30+00:00",
+        },
+    )
+    _write_json(
+        iteration_dir / "iteration_record.json",
+        {
+            "run_id": "run-single-ledger",
+            "iteration_number": 1,
+            "artifact_status": "completed",
+            "decision": "keep",
+        },
+    )
+    _write_results_tsv(repo_root / "experiments" / "results.tsv")
+
+    dashboard = observe_dashboard_state(
+        repo_root,
+        now=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+        stale_after_seconds=60,
+    )
+
+    assert len(dashboard["ledger"]["rows"]) == 1
+    assert "score" not in dashboard["iterations"][0]["metrics"]
+
+
+def test_observe_dashboard_state_hides_stale_iterations_without_run_state(tmp_path):
+    stale_iteration_dir = tmp_path / "experiments" / "iterations" / "old-run" / "iteration-0001"
+    _write_json(
+        stale_iteration_dir / "iteration_record.json",
+        {
+            "run_id": "old-run",
+            "iteration_number": 1,
+            "artifact_status": "completed",
+            "decision": "keep",
+        },
+    )
+
+    dashboard = observe_dashboard_state(
+        tmp_path,
+        now=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+        stale_after_seconds=60,
+    )
+
+    assert dashboard["run"]["status"] == "Waiting"
+    assert dashboard["iterations"] == []
+    assert dashboard["sources"]["active_run_root"] is None
+
+
+def test_observe_dashboard_state_uses_fresh_artifact_heartbeat_over_stale_log(tmp_path):
+    now = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    repo_root = tmp_path
+    iteration_dir = repo_root / "experiments" / "iterations" / "run-fresh-artifact" / "iteration-0001"
+
+    _write_json(
+        repo_root / "experiments" / "autoresearch_state.json",
+        {
+            "run_id": "run-fresh-artifact",
+            "status": "running",
+            "current_iteration": 1,
+            "active_iteration": 1,
+            "updated_at": "2026-04-19T10:00:00+00:00",
+        },
+    )
+    _write_json(
+        iteration_dir / "iteration_record.json",
+        {
+            "run_id": "run-fresh-artifact",
+            "iteration_number": 1,
+            "artifact_status": "running",
+            "artifact_paths": {
+                "context_json": str(iteration_dir / "context.json"),
+            },
+        },
+    )
+    _write_json(iteration_dir / "context.json", {"iteration": 1})
+    _touch_at(iteration_dir / "context.json", now.timestamp() - 2)
+    (iteration_dir / "claude.stdout.log").write_text("stale log\n", encoding="utf-8")
+    _touch_at(iteration_dir / "claude.stdout.log", now.timestamp() - 7200)
+
+    dashboard = observe_dashboard_state(repo_root, now=now, stale_after_seconds=60)
+
+    assert dashboard["run"]["status"] == "Busy"
+    assert dashboard["run"]["heartbeat"]["source_role"] == "artifact"
+    assert dashboard["run"]["heartbeat"]["path"] == str(iteration_dir / "context.json")
+    assert dashboard["run"]["heartbeat"]["age_seconds"] == pytest.approx(2)

--- a/tests/unit/test_dashboard_server.py
+++ b/tests/unit/test_dashboard_server.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from urllib.request import urlopen
+
+from src.dashboard.server import make_dashboard_handler, render_dashboard_index, render_iteration_detail_index
+
+
+def test_render_dashboard_index_contains_required_live_monitor_regions():
+    html = render_dashboard_index(refresh_seconds=2.5)
+
+    assert "Run Health Strip" in html
+    assert "Iteration Timeline" in html
+    assert "Selected Iteration Panel" in html
+    assert "Recent Activity" in html
+    assert "Artifact Availability" in html
+    assert "Performance Trend" in html
+    assert "Decision Summary" in html
+    assert "drawdown" in html
+    assert "turnover" in html
+    assert "deflated_sr" in html
+    assert "baseline delta" in html
+    assert "open-detail-link" in html
+    assert "formatDiagnosis" in html
+    assert "fetch('/api/state'" in html
+    assert "setInterval(loadDashboardState, 2500)" in html
+
+
+def test_render_iteration_detail_index_contains_drilldown_regions():
+    html = render_iteration_detail_index(2, refresh_seconds=1.5)
+
+    assert "Iteration Detail" in html
+    assert "iteration-detail-status" in html
+    assert "Hypothesis diff" in html
+    assert "Strategy diff" in html
+    assert "Metric breakdown" in html
+    assert "Decision reasoning" in html
+    assert "Artifact References" in html
+    assert "Log Excerpts" in html
+    assert "formatDiagnosis" in html
+    assert "vs previous iteration" in html
+    assert "setInterval(loadIterationDetail, 1500)" in html
+
+
+def test_dashboard_index_escapes_untrusted_strings_before_inner_html_rendering():
+    html = render_dashboard_index()
+
+    assert "const escapeHtml = value =>" in html
+    assert "${escapeHtml(run.status)}" in html
+    assert "${escapeHtml(run.run_id)}" in html
+    assert "${escapeHtml(formatDiagnosis(diagnosis, run.stop_reason)).replaceAll('\\n', '<br>')}" in html
+    assert "${escapeHtml(iteration.status)}" in html
+    assert "${escapeHtml(iteration.decision)}" in html
+    assert "${escapeHtml(nodeLabel(iteration))}" in html
+    assert "${escapeHtml(text(log.excerpt).slice(0, 180))}" in html
+    assert "${text(log.excerpt).slice(0, 180)}" not in html
+    assert "replace(/[^a-z0-9_-]/g, \"-\")" in html
+
+
+def test_dashboard_index_resets_selected_panel_when_no_iterations_render():
+    html = render_dashboard_index()
+
+    assert "resetSelectedPanel()" in html
+    assert "No iteration selected." in html
+    assert "No strategy change yet." in html
+    assert "No metrics yet." in html
+    assert "No decision yet." in html
+
+
+def test_iteration_detail_escapes_artifact_and_log_strings_before_inner_html_rendering():
+    html = render_iteration_detail_index(2)
+
+    assert "const escapeHtml = value =>" in html
+    assert "<td>${escapeHtml(item.name)}</td>" in html
+    assert '<td class="muted">${escapeHtml(item.path)}</td>' in html
+    assert "${escapeHtml(log.updated_at)}" in html
+    assert '<span class="muted">${escapeHtml(log.path)}</span>' in html
+    assert "<pre>${escapeHtml(log.excerpt)}</pre>" in html
+    assert "${text(item.path)}" not in html
+    assert "${text(log.excerpt)}" not in html
+
+
+def test_iteration_detail_resets_missing_iteration_sections():
+    html = render_iteration_detail_index(2)
+
+    assert "resetMissingIterationDetail()" in html
+    assert "No iteration selected." in html
+    assert "No artifact references yet." in html
+    assert "No logs yet." in html
+
+
+def test_dashboard_handler_serves_index_and_observer_json(tmp_path):
+    state_path = tmp_path / "experiments" / "autoresearch_state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "run_id": "run-test",
+                "status": "running",
+                "current_iteration": 0,
+                "active_iteration": None,
+                "updated_at": "2026-04-20T00:00:00+00:00",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    handler = make_dashboard_handler(tmp_path, refresh_seconds=1.0)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        host, port = server.server_address
+        with urlopen(f"http://{host}:{port}/", timeout=5) as response:
+            html = response.read().decode("utf-8")
+            assert response.status == 200
+            assert "Run Health Strip" in html
+
+        with urlopen(f"http://{host}:{port}/api/state", timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            assert response.status == 200
+            assert payload["run"]["run_id"] == "run-test"
+            assert sorted(payload.keys()) == ["iterations", "ledger", "observed_at", "run", "sources"]
+
+        with urlopen(f"http://{host}:{port}/iterations/1", timeout=5) as response:
+            html = response.read().decode("utf-8")
+            assert response.status == 200
+            assert "Iteration Detail" in html
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)


### PR DESCRIPTION
## Summary
- add a local read-only dashboard command, observer layer, home/detail views, and regression coverage for run health and iteration analysis
- harden dashboard rendering and observer correlation logic for escaped artifact text, repo-relative paths, explicit ledger matching, active-run selection, and freshest-heartbeat handling
- archive the completed OpenSpec change and sync its capability deltas into `openspec/specs/`

## Test Plan
- [x] `uv run pytest tests/unit/test_dashboard_server.py tests/unit/test_dashboard_observer.py tests/integration/test_dashboard_validation.py -q`
- [x] `uv run pytest -q`
- [x] `uv run python cli.py dashboard --help`
- [x] `uv run python -m py_compile src/dashboard/observer.py src/dashboard/server.py tests/unit/test_dashboard_observer.py tests/unit/test_dashboard_server.py tests/integration/test_dashboard_validation.py`
